### PR TITLE
[refactor]: CORS 에러 처리 및 controller 수정

### DIFF
--- a/src/main/java/com/picktory/domain/user/controller/UserController.java
+++ b/src/main/java/com/picktory/domain/user/controller/UserController.java
@@ -17,9 +17,9 @@ public class UserController {
     private final UserService userService;
 
     // 카카오 소셜 로그인
-    @PostMapping("/oauth/login")
-    public BaseResponse<UserLoginResponse> login(@RequestBody UserLoginRequest request) {
-        UserLoginResponse response = userService.login(request.getCode());
+    @GetMapping("/oauth/login")
+    public BaseResponse<UserLoginResponse> login(@RequestParam String code) {
+        UserLoginResponse response = userService.login(code);
         return new BaseResponse<>(response);
     }
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
CORS 에러 처리 및 카카오 로그인 인증 관련 수정

## 🔍 주요 변경사항
- SecurityConfig 수정
  - 허용된 origin 목록 확장 (localhost:3000, localhost:8080 추가)
  - OPTIONS 메소드 CORS 허용 목록에 추가
  - 엔드포인트 권한 설정 리팩토링 (public/authenticated 분리)
- UserController 수정
  - 카카오 로그인 엔드포인트 메소드 POST → GET 변경
  - Request 파라미터 형식 @RequestBody → @RequestParam 변경

## 🔗 연관된 이슈
CORS 정책 위반 및 카카오 OAuth 리다이렉트 URI 불일치 문제 해결

## ✅ 체크리스트
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?
- [x] Breaking Change가 있나요? (카카오 로그인 API 메소드 변경)
- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
- 현재 운영 환경에서 발생하는 SecurityConfig 빌드 오류 해결을 위한 변경사항 포함
- 로컬/운영 환경 모두에서 원활한 카카오 로그인 흐름을 위한 설정 통합