### PR TITLE
[Feature/bundle delivery] 배달부 캐릭터 선택 구현

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -24,6 +24,11 @@ public enum BaseResponseStatus {
     BUNDLE_DESIGN_REQUIRED(false, 400, "보따리 디자인을 선택하세요."),
     BUNDLE_MINIMUM_GIFTS_REQUIRED(false, 400, "보따리는 최소 2개의 선물을 포함해야 합니다."),
 
+    BUNDLE_NOT_FOUND(false, 404, "보따리를 찾을 수 없습니다."),
+    INVALID_BUNDLE_STATUS(false, 400, "이미 배달이 시작된 보따리입니다."),
+    INVALID_CHARACTER_TYPE(false, 400, "유효하지 않은 배달부 캐릭터입니다."),
+    INVALID_LINK(false, 400, "유효하지 않은 배달 링크입니다."),
+    INVALID_BUNDLE_STATUS_FOR_COMPLETE(false, 400, "PUBLISHED 상태에서만 COMPLETED로 변경 가능합니다."),
 
     /**
      * 500: Server 오류

--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -23,4 +23,15 @@ public class BundleController {
     public ResponseEntity<BundleResponse> createBundle(@Valid @RequestBody BundleRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(bundleService.createBundle(request));
     }
+
+    /**
+     * 배달부 캐릭터 설정 API
+     */
+    @PutMapping("/{id}/delivery")
+    public ResponseEntity<BundleResponse> updateDeliveryCharacter(
+            @PathVariable Long id,
+            @Valid @RequestBody BundleRequest request
+    ) {
+        return ResponseEntity.ok(bundleService.updateDeliveryCharacter(id, request));
+    }
 }

--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -1,5 +1,6 @@
 package com.picktory.domain.bundle.controller;
 
+import com.picktory.domain.bundle.dto.BundleDeliveryRequest;
 import com.picktory.domain.bundle.dto.BundleRequest;
 import com.picktory.domain.bundle.dto.BundleResponse;
 import com.picktory.domain.bundle.service.BundleService;
@@ -30,7 +31,7 @@ public class BundleController {
     @PutMapping("/{id}/delivery")
     public ResponseEntity<BundleResponse> updateDeliveryCharacter(
             @PathVariable Long id,
-            @Valid @RequestBody BundleRequest request
+            @Valid @RequestBody BundleDeliveryRequest request
     ) {
         return ResponseEntity.ok(bundleService.updateDeliveryCharacter(id, request));
     }

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleDeliveryRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleDeliveryRequest.java
@@ -1,0 +1,13 @@
+package com.picktory.domain.bundle.dto;
+
+import com.picktory.domain.bundle.enums.DeliveryCharacterType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BundleDeliveryRequest {
+    @NotNull(message = "배달부 캐릭터를 선택해주세요.")
+    private DeliveryCharacterType deliveryCharacterType;
+}

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
@@ -21,6 +21,4 @@ public class BundleRequest {
     @NotNull
     @Size(min = 2)
     private List<GiftRequest> gifts;
-
-    private DeliveryCharacterType deliveryCharacterType;
 }

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
@@ -1,5 +1,6 @@
 package com.picktory.domain.bundle.dto;
 
+import com.picktory.domain.bundle.enums.DeliveryCharacterType;
 import com.picktory.domain.bundle.enums.DesignType;
 import com.picktory.domain.gift.dto.GiftRequest;
 import jakarta.validation.constraints.NotNull;
@@ -20,4 +21,6 @@ public class BundleRequest {
     @NotNull
     @Size(min = 2)
     private List<GiftRequest> gifts;
+
+    private DeliveryCharacterType deliveryCharacterType;
 }

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleResponse.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleResponse.java
@@ -56,4 +56,13 @@ public class BundleResponse {
                                 .collect(Collectors.toList()))
                 .build();
     }
+
+    public static BundleResponse fromEntityForDeliveryCharacter(Bundle bundle) {
+        return BundleResponse.builder()
+                .id(bundle.getId())
+                .deliveryCharacterType(bundle.getDeliveryCharacterType())
+                .status(bundle.getStatus())
+                .updatedAt(bundle.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleResponse.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleResponse.java
@@ -56,13 +56,4 @@ public class BundleResponse {
                                 .collect(Collectors.toList()))
                 .build();
     }
-
-    public static BundleResponse fromEntityForDeliveryCharacter(Bundle bundle) {
-        return BundleResponse.builder()
-                .id(bundle.getId())
-                .deliveryCharacterType(bundle.getDeliveryCharacterType())
-                .status(bundle.getStatus())
-                .updatedAt(bundle.getUpdatedAt())
-                .build();
-    }
 }

--- a/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
+++ b/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
@@ -8,6 +8,7 @@ import com.picktory.domain.bundle.enums.DesignType;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name = "bundles")
@@ -35,7 +36,7 @@ public class Bundle {
     @Column(nullable = true) // NULL 허용
     private DeliveryCharacterType deliveryCharacterType;
 
-    @Column(length = 255)
+    @Column(nullable = false, unique = true)
     private String link; // 배달용 링크 (없으면 PUBLISHED 불가)
 
     @Enumerated(EnumType.STRING)
@@ -58,9 +59,12 @@ public class Bundle {
     /**
      * 배달부 캐릭터 설정
      */
-    public void updateDeliveryCharacter(DeliveryCharacterType type) {
+    public void updateDeliveryCharacter(DeliveryCharacterType type, String link) {
         validateDraftStatus();
+        validateDeliveryCharacter(type);
+
         this.deliveryCharacterType = type;
+        this.link = link;
         this.status = BundleStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
     }
@@ -103,6 +107,11 @@ public class Bundle {
     public void markAsRead() {
         if (this.status == BundleStatus.COMPLETED && this.isRead == Boolean.FALSE) {
             this.isRead = true;
+        }
+    }
+    private void validateDeliveryCharacter(DeliveryCharacterType type) {
+        if (type == null) {
+            throw new BaseException(BaseResponseStatus.INVALID_CHARACTER_TYPE);
         }
     }
 }

--- a/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
+++ b/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
@@ -1,5 +1,7 @@
 package com.picktory.domain.bundle.entity;
 
+import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
 import com.picktory.domain.bundle.enums.BundleStatus;
 import com.picktory.domain.bundle.enums.DeliveryCharacterType;
 import com.picktory.domain.bundle.enums.DesignType;
@@ -54,11 +56,30 @@ public class Bundle {
     private Boolean isRead = false; // 응답 확인 여부 (기본값: false)
 
     /**
+     * 배달부 캐릭터 설정
+     */
+    public void updateDeliveryCharacter(DeliveryCharacterType type) {
+        validateDraftStatus();
+        this.deliveryCharacterType = type;
+        this.status = BundleStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    /**
+     * DRAFT 상태 검증
+     */
+    private void validateDraftStatus() {
+        if (this.status != BundleStatus.DRAFT) {
+            throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS);
+        }
+    }
+
+    /**
      * 보따리 배달 완료 후, 배달 정보가 설정되었을 때 PUBLISHED 상태로 변경
      */
     public void publish(String link, DeliveryCharacterType characterType) {
         if (link == null || link.isEmpty()) {
-            throw new IllegalStateException("배달 링크가 설정되지 않았습니다.");
+            throw new BaseException(BaseResponseStatus.INVALID_CHARACTER_TYPE);
         }
         this.link = link;
         this.deliveryCharacterType = characterType;
@@ -71,7 +92,7 @@ public class Bundle {
      */
     public void complete() {
         if (this.status != BundleStatus.PUBLISHED) {
-            throw new IllegalStateException("PUBLISHED 상태에서만 COMPLETED로 변경 가능합니다.");
+            throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS_FOR_COMPLETE);
         }
         this.status = BundleStatus.COMPLETED;
     }

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
@@ -10,6 +10,6 @@ public interface BundleRepository extends JpaRepository<Bundle, Long> {
      * 특정 사용자가 오늘 생성한 보따리 개수 조회
      */
     long countByUserIdAndCreatedAtAfter(Long userId, LocalDateTime today);
-
+    Optional<Bundle> findByLink(String link);
     Optional<Bundle> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
@@ -2,7 +2,7 @@ package com.picktory.domain.bundle.repository;
 
 import com.picktory.domain.bundle.entity.Bundle;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.util.Optional;
 import java.time.LocalDateTime;
 
 public interface BundleRepository extends JpaRepository<Bundle, Long> {
@@ -10,4 +10,6 @@ public interface BundleRepository extends JpaRepository<Bundle, Long> {
      * 특정 사용자가 오늘 생성한 보따리 개수 조회
      */
     long countByUserIdAndCreatedAtAfter(Long userId, LocalDateTime today);
+
+    Optional<Bundle> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -3,6 +3,7 @@ package com.picktory.domain.bundle.service;
 import com.picktory.common.BaseResponseStatus;
 import com.picktory.common.exception.BaseException;
 import com.picktory.config.auth.AuthenticationService;
+import com.picktory.domain.bundle.dto.BundleDeliveryRequest;
 import com.picktory.domain.bundle.dto.BundleRequest;
 import com.picktory.domain.bundle.dto.BundleResponse;
 import com.picktory.domain.bundle.entity.Bundle;
@@ -111,7 +112,7 @@ public class BundleService {
     /**
      * 배달부 캐릭터 설정
      */
-    public BundleResponse updateDeliveryCharacter(Long bundleId, BundleRequest request) {
+    public BundleResponse updateDeliveryCharacter(Long bundleId, BundleDeliveryRequest request) {
         // 현재 로그인한 유저 가져오기
         User currentUser = authenticationService.getAuthenticatedUser();
 
@@ -125,7 +126,10 @@ public class BundleService {
         // 배달부 캐릭터 설정 및 링크 저장
         bundle.updateDeliveryCharacter(request.getDeliveryCharacterType(), link);
 
+        // 변경사항 DB에 저장
+        Bundle savedBundle = bundleRepository.save(bundle);
+
         // 변경된 보따리 정보 반환
-        return BundleResponse.fromEntity(bundle, null, null);
+        return BundleResponse.fromEntity(savedBundle, null, null);
     }
 }

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -106,4 +106,22 @@ public class BundleService {
             //
         return BundleResponse.fromEntity(bundle, savedGifts, savedGiftImages);
     }
+
+    /**
+     * 배달부 캐릭터 설정
+     */
+    public BundleResponse updateDeliveryCharacter(Long bundleId, BundleRequest request) {
+        // 현재 로그인한 유저 가져오기
+        User currentUser = authenticationService.getAuthenticatedUser();
+
+        // 보따리 조회
+        Bundle bundle = bundleRepository.findByIdAndUserId(bundleId, currentUser.getId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.BUNDLE_NOT_FOUND));
+
+        // 배달부 캐릭터 설정
+        bundle.updateDeliveryCharacter(request.getDeliveryCharacterType());
+
+        // 변경된 보따리 정보만 반환
+        return BundleResponse.fromEntity(bundle, null, null);
+    }
 }

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -118,10 +119,13 @@ public class BundleService {
         Bundle bundle = bundleRepository.findByIdAndUserId(bundleId, currentUser.getId())
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.BUNDLE_NOT_FOUND));
 
-        // 배달부 캐릭터 설정
-        bundle.updateDeliveryCharacter(request.getDeliveryCharacterType());
+        // 배달 링크 생성 (UUID로 고유성 보장)
+        String link = "/delivery/" + UUID.randomUUID().toString();
 
-        // 변경된 보따리 정보만 반환
+        // 배달부 캐릭터 설정 및 링크 저장
+        bundle.updateDeliveryCharacter(request.getDeliveryCharacterType(), link);
+
+        // 변경된 보따리 정보 반환
         return BundleResponse.fromEntity(bundle, null, null);
     }
 }

--- a/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
+++ b/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
@@ -209,6 +209,8 @@ class BundleServiceTest {
         // Then
         assertThat(response.getDeliveryCharacterType()).isEqualTo(DeliveryCharacterType.CHARACTER_1);
         assertThat(response.getStatus()).isEqualTo(BundleStatus.PUBLISHED);
+        assertThat(response.getLink()).isNotNull();  // 링크 생성 확인
+        assertThat(response.getLink()).startsWith("/delivery/");  // 링크 형식 확인
     }
 
     @Test
@@ -244,6 +246,7 @@ class BundleServiceTest {
                 .designType(DesignType.RED)
                 .status(BundleStatus.PUBLISHED) // 이미 PUBLISHED 상태
                 .deliveryCharacterType(DeliveryCharacterType.CHARACTER_2)
+                .link("/delivery/existing-link")
                 .isRead(false)
                 .build();
 

--- a/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
+++ b/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
@@ -3,6 +3,7 @@ package com.picktory.bundle.service;
 import com.picktory.common.BaseResponseStatus;
 import com.picktory.common.exception.BaseException;
 import com.picktory.config.auth.AuthenticationService;
+import com.picktory.domain.bundle.dto.BundleDeliveryRequest;
 import com.picktory.domain.bundle.dto.BundleRequest;
 import com.picktory.domain.bundle.dto.BundleResponse;
 import com.picktory.domain.bundle.enums.DesignType;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -188,7 +190,7 @@ class BundleServiceTest {
     void updateDeliveryCharacter_성공() {
         // Given
         Long bundleId = 1L;
-        BundleRequest request = new BundleRequest();
+        BundleDeliveryRequest request = new BundleDeliveryRequest();
         request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
 
         Bundle mockBundle = Bundle.builder()
@@ -202,6 +204,8 @@ class BundleServiceTest {
 
         when(bundleRepository.findByIdAndUserId(bundleId, mockUser.getId()))
                 .thenReturn(Optional.of(mockBundle));
+        when(bundleRepository.save(any(Bundle.class)))
+                .thenReturn(mockBundle);
 
         // When
         BundleResponse response = bundleService.updateDeliveryCharacter(bundleId, request);
@@ -209,8 +213,10 @@ class BundleServiceTest {
         // Then
         assertThat(response.getDeliveryCharacterType()).isEqualTo(DeliveryCharacterType.CHARACTER_1);
         assertThat(response.getStatus()).isEqualTo(BundleStatus.PUBLISHED);
-        assertThat(response.getLink()).isNotNull();  // 링크 생성 확인
-        assertThat(response.getLink()).startsWith("/delivery/");  // 링크 형식 확인
+        assertThat(response.getLink()).isNotNull();
+        assertThat(response.getLink()).startsWith("/delivery/");
+
+        verify(bundleRepository).save(any(Bundle.class));
     }
 
     @Test
@@ -218,7 +224,7 @@ class BundleServiceTest {
     void updateDeliveryCharacter_실패_보따리없음() {
         // Given
         Long bundleId = 999L;
-        BundleRequest request = new BundleRequest();
+        BundleDeliveryRequest request = new BundleDeliveryRequest();
         request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
 
         when(bundleRepository.findByIdAndUserId(bundleId, mockUser.getId()))
@@ -230,13 +236,12 @@ class BundleServiceTest {
 
         assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.BUNDLE_NOT_FOUND);
     }
-
     @Test
     @DisplayName("❌ 배달부 캐릭터 설정 실패 - 이미 배달 시작된 보따리")
     void updateDeliveryCharacter_실패_이미배달시작() {
         // Given
         Long bundleId = 1L;
-        BundleRequest request = new BundleRequest();
+        BundleDeliveryRequest request = new BundleDeliveryRequest(); // BundleRequest에서 BundleDeliveryRequest로 변경
         request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
 
         Bundle mockBundle = Bundle.builder()

--- a/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
+++ b/src/test/java/com/picktory/bundle/service/BundleServiceTest.java
@@ -10,6 +10,7 @@ import com.picktory.domain.bundle.service.BundleService;
 import com.picktory.domain.bundle.repository.BundleRepository;
 import com.picktory.domain.bundle.entity.Bundle;
 import com.picktory.domain.bundle.enums.BundleStatus;
+import com.picktory.domain.bundle.enums.DeliveryCharacterType;
 import com.picktory.domain.gift.dto.GiftRequest;
 import com.picktory.domain.gift.entity.Gift;
 import com.picktory.domain.gift.entity.GiftImage;
@@ -30,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -180,5 +182,78 @@ class BundleServiceTest {
         // When & Then
         BaseException exception = assertThrows(BaseException.class, () -> bundleService.createBundle(request));
         assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.BUNDLE_MINIMUM_GIFTS_REQUIRED);
+    }
+    @Test
+    @DisplayName("✅ 배달부 캐릭터 설정 성공")
+    void updateDeliveryCharacter_성공() {
+        // Given
+        Long bundleId = 1L;
+        BundleRequest request = new BundleRequest();
+        request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
+
+        Bundle mockBundle = Bundle.builder()
+                .id(bundleId)
+                .userId(mockUser.getId())
+                .name("Test Bundle")
+                .designType(DesignType.RED)
+                .status(BundleStatus.DRAFT)
+                .isRead(false)
+                .build();
+
+        when(bundleRepository.findByIdAndUserId(bundleId, mockUser.getId()))
+                .thenReturn(Optional.of(mockBundle));
+
+        // When
+        BundleResponse response = bundleService.updateDeliveryCharacter(bundleId, request);
+
+        // Then
+        assertThat(response.getDeliveryCharacterType()).isEqualTo(DeliveryCharacterType.CHARACTER_1);
+        assertThat(response.getStatus()).isEqualTo(BundleStatus.PUBLISHED);
+    }
+
+    @Test
+    @DisplayName("❌ 배달부 캐릭터 설정 실패 - 보따리를 찾을 수 없음")
+    void updateDeliveryCharacter_실패_보따리없음() {
+        // Given
+        Long bundleId = 999L;
+        BundleRequest request = new BundleRequest();
+        request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
+
+        when(bundleRepository.findByIdAndUserId(bundleId, mockUser.getId()))
+                .thenReturn(Optional.empty());
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class,
+                () -> bundleService.updateDeliveryCharacter(bundleId, request));
+
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.BUNDLE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("❌ 배달부 캐릭터 설정 실패 - 이미 배달 시작된 보따리")
+    void updateDeliveryCharacter_실패_이미배달시작() {
+        // Given
+        Long bundleId = 1L;
+        BundleRequest request = new BundleRequest();
+        request.setDeliveryCharacterType(DeliveryCharacterType.CHARACTER_1);
+
+        Bundle mockBundle = Bundle.builder()
+                .id(bundleId)
+                .userId(mockUser.getId())
+                .name("Test Bundle")
+                .designType(DesignType.RED)
+                .status(BundleStatus.PUBLISHED) // 이미 PUBLISHED 상태
+                .deliveryCharacterType(DeliveryCharacterType.CHARACTER_2)
+                .isRead(false)
+                .build();
+
+        when(bundleRepository.findByIdAndUserId(bundleId, mockUser.getId()))
+                .thenReturn(Optional.of(mockBundle));
+
+        // When & Then
+        BaseException exception = assertThrows(BaseException.class,
+                () -> bundleService.updateDeliveryCharacter(bundleId, request));
+
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.INVALID_BUNDLE_STATUS);
     }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
배달부 캐릭터 선택 기능 구현

## 🔍 주요 변경사항
- BaseResponseStatus에 배달부 관련 예외코드 추가
- Bundle 엔티티 
- API 구현
- 서비스 로직


## 🔗 연관된 이슈
배달부 캐릭터 선택 기능

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
굳이 delivery 도메인으로 나눌 필요성을 못 느껴서 bundle 도메인에다 짰습니다.

도메인을 bundle과 delivery로 나눠야 할지는 고민이 되긴하네요