### PR TITLE
[build]: hibernate.validator 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'com.mysql:mysql-connector-j:8.0.33'
+    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
+    implementation 'org.glassfish:jakarta.el:4.0.2'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> Hibernate Validator(Bean Validation Provider)가 없어서 Hibernate가 테이블을 생성하지 못하고 실패함. 
Spring Boot 3.0 이상에서는 jakarta.validation을 지원하므로, hibernate-validator를 build.gradle에 추가해야 해서 hibernate.validator 추가

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
