### PR TITLE
[Feature/bundle-open] 보따리 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
+    set('queryDslVersion', '5.0.0')
 }
 
 dependencies {
@@ -43,10 +44,12 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     // QueryDSL
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+    annotationProcessor(
+            "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta",
+            "jakarta.annotation:jakarta.annotation-api",
+            "jakarta.persistence:jakarta.persistence-api"
+    )
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -72,11 +75,16 @@ tasks.named('asciidoctor') {
     dependsOn test
 }
 
-// QueryDSL 제거하고 빌드 테스트
+def querydslDir = "$buildDir/generated/querydsl"
+
 sourceSets {
-    main {
-        java {
-            srcDirs = ["src/main/java"]
-        }
-    }
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -28,6 +28,7 @@ public enum BaseResponseStatus {
     INVALID_BUNDLE_STATUS(false, 400, "이미 배달이 시작된 보따리입니다."),
     INVALID_CHARACTER_TYPE(false, 400, "유효하지 않은 배달부 캐릭터입니다."),
     INVALID_LINK(false, 400, "유효하지 않은 배달 링크입니다."),
+    NOT_DELIVERED_YET(false, 400 ,"아직 배송 상태가 아닙니다" ),
     INVALID_BUNDLE_STATUS_FOR_COMPLETE(false, 400, "PUBLISHED 상태에서만 COMPLETED로 변경 가능합니다."),
 
     /**

--- a/src/main/java/com/picktory/domain/gift/entity/Gift.java
+++ b/src/main/java/com/picktory/domain/gift/entity/Gift.java
@@ -51,4 +51,8 @@ public class Gift {
                 .isResponsed(false)
                 .build();
     }
+    // 응답 상태 변경 메서드
+    public void setResponded(boolean responded) {
+        this.isResponsed = responded;
+    }
 }

--- a/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
+++ b/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface GiftImageRepository extends JpaRepository<GiftImage, Long> {
     List<GiftImage> findByGiftId(Long giftId);
+    List<GiftImage> findByGiftIdIn(List<Long> giftIds);
 }

--- a/src/main/java/com/picktory/domain/response/controller/ResponseController.java
+++ b/src/main/java/com/picktory/domain/response/controller/ResponseController.java
@@ -1,0 +1,21 @@
+package com.picktory.domain.response.controller;
+
+import com.picktory.common.BaseResponse;
+import com.picktory.domain.response.dto.ResponseBundleDto;
+import com.picktory.domain.response.service.ResponseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/responses")
+public class ResponseController {
+    private final ResponseService responseService;
+
+    @GetMapping("/bundles/{link}")
+    public ResponseEntity<BaseResponse<ResponseBundleDto>> getBundleByLink(@PathVariable String link) {
+        ResponseBundleDto response = responseService.getBundleByLink(link);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+}

--- a/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
+++ b/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
@@ -1,0 +1,66 @@
+package com.picktory.domain.response.dto;
+
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ResponseBundleDto {
+    private BundleInfo bundle;
+
+    @Getter
+    @Builder
+    public static class BundleInfo {
+        private String delivery_character_type;
+        private String status;
+        private List<GiftInfo> gifts;
+        private int total_gifts;
+    }
+
+    @Getter
+    @Builder
+    public static class GiftInfo {
+        private Long id;
+        private String message;
+        private List<String> imageUrls;
+        private String thumbnail;
+    }
+
+    public static ResponseBundleDto fromEntity(Bundle bundle, List<Gift> gifts, List<GiftImage> images) {
+        List<GiftInfo> giftInfos = gifts.stream()
+                .map(gift -> {
+                    List<GiftImage> giftImages = images.stream()
+                            .filter(img -> img.getGiftId().equals(gift.getId()))
+                            .collect(Collectors.toList());
+
+                    return GiftInfo.builder()
+                            .id(gift.getId())
+                            .message(null) // 선물이 열리기 전에는 null
+                            .imageUrls(giftImages.stream()
+                                    .filter(img -> !img.getIsPrimary())
+                                    .map(GiftImage::getImageUrl)
+                                    .collect(Collectors.toList()))
+                            .thumbnail(giftImages.stream()
+                                    .filter(GiftImage::getIsPrimary)
+                                    .findFirst()
+                                    .map(GiftImage::getImageUrl)
+                                    .orElse(null))
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return ResponseBundleDto.builder()
+                .bundle(BundleInfo.builder()
+                        .delivery_character_type(bundle.getDeliveryCharacterType().name())
+                        .status(bundle.getStatus().name())
+                        .gifts(giftInfos)
+                        .total_gifts(gifts.size())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/response/entity/Response.java
+++ b/src/main/java/com/picktory/domain/response/entity/Response.java
@@ -1,0 +1,30 @@
+package com.picktory.domain.response.entity;
+
+import com.picktory.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "responses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Response extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "gift_id", nullable = false)
+    private Long giftId;
+
+    @Column(name = "bundle_id", nullable = false)
+    private Long bundleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "response_tag", nullable = false)
+    private ResponseTag responseTag;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+}

--- a/src/main/java/com/picktory/domain/response/entity/ResponseTag.java
+++ b/src/main/java/com/picktory/domain/response/entity/ResponseTag.java
@@ -1,0 +1,9 @@
+package com.picktory.domain.response.entity;
+
+public enum ResponseTag {
+    OPTION_1,
+    OPTION_2,
+    OPTION_3,
+    OPTION_4,
+    OPTION_5
+}

--- a/src/main/java/com/picktory/domain/response/repository/ResponseRepository.java
+++ b/src/main/java/com/picktory/domain/response/repository/ResponseRepository.java
@@ -1,0 +1,8 @@
+package com.picktory.domain.response.repository;
+
+import com.picktory.domain.response.entity.Response;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResponseRepository extends JpaRepository<Response, Long>, ResponseRepositoryCustom {
+    boolean existsByGiftId(Long giftId);
+}

--- a/src/main/java/com/picktory/domain/response/repository/ResponseRepositoryCustom.java
+++ b/src/main/java/com/picktory/domain/response/repository/ResponseRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.picktory.domain.response.repository;
+
+import com.picktory.domain.response.entity.Response;
+import java.util.List;
+
+public interface ResponseRepositoryCustom {
+    List<Response> findAllByBundleIdAndGiftIds(Long bundleId, List<Long> giftIds);
+}

--- a/src/main/java/com/picktory/domain/response/repository/ResponseRepositoryImpl.java
+++ b/src/main/java/com/picktory/domain/response/repository/ResponseRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.picktory.domain.response.repository;
+
+import com.picktory.domain.response.entity.QResponse;
+import com.picktory.domain.response.entity.Response;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ResponseRepositoryImpl implements ResponseRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private final QResponse response = QResponse.response;
+
+    @Override
+    public List<Response> findAllByBundleIdAndGiftIds(Long bundleId, List<Long> giftIds) {
+        return queryFactory
+                .selectFrom(response)
+                .where(
+                        bundleIdEq(bundleId),
+                        giftIdsIn(giftIds)
+                )
+                .orderBy(response.createdAt.desc())
+                .fetch();
+    }
+
+    private BooleanExpression bundleIdEq(Long bundleId) {
+        return bundleId != null ? response.bundleId.eq(bundleId) : null;
+    }
+
+    private BooleanExpression giftIdsIn(List<Long> giftIds) {
+        return giftIds != null && !giftIds.isEmpty() ? response.giftId.in(giftIds) : null;
+    }
+}

--- a/src/main/java/com/picktory/domain/response/service/ResponseService.java
+++ b/src/main/java/com/picktory/domain/response/service/ResponseService.java
@@ -1,0 +1,111 @@
+package com.picktory.domain.response.service;
+
+import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.bundle.repository.BundleRepository;
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import com.picktory.domain.gift.repository.GiftImageRepository;
+import com.picktory.domain.gift.repository.GiftRepository;
+import com.picktory.domain.response.dto.ResponseBundleDto;
+import com.picktory.domain.response.entity.Response;
+import com.picktory.domain.response.entity.ResponseTag;
+import com.picktory.domain.response.repository.ResponseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResponseService {
+    private final BundleRepository bundleRepository;
+    private final GiftRepository giftRepository;
+    private final GiftImageRepository giftImageRepository;
+    private final ResponseRepository responseRepository;
+
+    public ResponseBundleDto getBundleByLink(String link) {
+        Bundle bundle = findBundleByLink(link);
+        validateBundleStatus(bundle);
+
+        List<Gift> gifts = findGiftsByBundleId(bundle.getId());
+        List<GiftImage> images = findGiftImages(gifts);
+        List<Response> responses = findResponses(bundle.getId(), gifts);
+
+        updateGiftResponseStatus(gifts, responses);
+
+        return ResponseBundleDto.fromEntity(bundle, gifts, images);
+    }
+
+    @Transactional
+    public void createResponse(Long giftId, Long bundleId, ResponseTag responseTag, String message) {
+        validateResponseNotExists(giftId);
+        Response response = buildResponse(giftId, bundleId, responseTag, message);
+        responseRepository.save(response);
+    }
+
+    private Bundle findBundleByLink(String link) {
+        return bundleRepository.findByLink(link)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.INVALID_LINK));
+    }
+
+    private List<Gift> findGiftsByBundleId(Long bundleId) {
+        return giftRepository.findByBundleId(bundleId);
+    }
+
+    private List<GiftImage> findGiftImages(List<Gift> gifts) {
+        return giftImageRepository.findByGiftIdIn(
+                gifts.stream()
+                        .map(Gift::getId)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private List<Response> findResponses(Long bundleId, List<Gift> gifts) {
+        return responseRepository.findAllByBundleIdAndGiftIds(
+                bundleId,
+                gifts.stream()
+                        .map(Gift::getId)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    private void validateBundleStatus(Bundle bundle) {
+        switch (bundle.getStatus()) {
+            case DRAFT -> throw new BaseException(BaseResponseStatus.NOT_DELIVERED_YET);
+            case COMPLETED -> throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS);
+            case PUBLISHED -> { /* 정상 처리 */ }
+            default -> throw new BaseException(BaseResponseStatus.INVALID_LINK);
+        }
+    }
+
+    private void validateResponseNotExists(Long giftId) {
+        if (responseRepository.existsByGiftId(giftId)) {
+            throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS);
+        }
+    }
+
+    private Response buildResponse(Long giftId, Long bundleId, ResponseTag responseTag, String message) {
+        return Response.builder()
+                .giftId(giftId)
+                .bundleId(bundleId)
+                .responseTag(responseTag)
+                .message(message)
+                .build();
+    }
+
+    private void updateGiftResponseStatus(List<Gift> gifts, List<Response> responses) {
+        List<Long> respondedGiftIds = responses.stream()
+                .map(Response::getGiftId)
+                .collect(Collectors.toList());
+
+        gifts.forEach(gift -> {
+            if (respondedGiftIds.contains(gift.getId())) {
+                gift.setResponded(true);
+            }
+        });
+    }
+}

--- a/src/test/java/com/picktory/response/service/ResponseServiceTest.java
+++ b/src/test/java/com/picktory/response/service/ResponseServiceTest.java
@@ -1,0 +1,162 @@
+package com.picktory.response.service;
+
+import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.bundle.enums.BundleStatus;
+import com.picktory.domain.bundle.enums.DeliveryCharacterType;
+import com.picktory.domain.bundle.enums.DesignType;
+import com.picktory.domain.bundle.repository.BundleRepository;
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import com.picktory.domain.gift.repository.GiftImageRepository;
+import com.picktory.domain.gift.repository.GiftRepository;
+import com.picktory.domain.response.dto.ResponseBundleDto;
+import com.picktory.domain.response.entity.Response;
+import com.picktory.domain.response.repository.ResponseRepository;
+import com.picktory.domain.response.service.ResponseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResponseServiceTest {
+
+    @InjectMocks
+    private ResponseService responseService;
+
+    @Mock
+    private BundleRepository bundleRepository;
+    @Mock
+    private GiftRepository giftRepository;
+    @Mock
+    private GiftImageRepository giftImageRepository;
+    @Mock
+    private ResponseRepository responseRepository;
+
+    private Bundle createTestBundle(Long id, String link, BundleStatus status) {
+        return Bundle.builder()
+                .id(id)
+                .userId(1L)
+                .name("테스트 보따리")
+                .designType(DesignType.RED)
+                .deliveryCharacterType(DeliveryCharacterType.CHARACTER_1)
+                .link(link)
+                .status(status)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .publishedAt(status == BundleStatus.PUBLISHED ? LocalDateTime.now() : null)
+                .isRead(false)
+                .build();
+    }
+
+    private Gift createTestGift(Long id, Long bundleId) {
+        return Gift.builder()
+                .id(id)
+                .bundleId(bundleId)
+                .name("테스트 선물")
+                .message("테스트 메시지")
+                .purchaseUrl("http://test.com")
+                .isResponsed(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private GiftImage createTestGiftImage(Long giftId, boolean isPrimary) {
+        return GiftImage.builder()
+                .id(1L)
+                .giftId(giftId)
+                .imageUrl("http://example.com/image.jpg")
+                .isPrimary(isPrimary)
+                .uploadedAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("선물 보따리 조회")
+    class GetBundle {
+
+        @Test
+        @DisplayName("PUBLISHED 상태의 보따리를 정상적으로 조회할 수 있다")
+        void success() {
+            // given
+            String link = "valid-link";
+            Bundle bundle = createTestBundle(1L, link, BundleStatus.PUBLISHED);
+            Gift gift = createTestGift(1L, bundle.getId());
+            GiftImage thumbnail = createTestGiftImage(gift.getId(), true);
+            GiftImage additionalImage = createTestGiftImage(gift.getId(), false);
+            List<Response> responses = List.of();
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+            when(giftRepository.findByBundleId(bundle.getId())).thenReturn(List.of(gift));
+            when(giftImageRepository.findByGiftIdIn(any())).thenReturn(List.of(thumbnail, additionalImage));
+            when(responseRepository.findAllByBundleIdAndGiftIds(anyLong(), any())).thenReturn(responses);
+
+            // when
+            ResponseBundleDto result = responseService.getBundleByLink(link);
+
+            // then
+            assertThat(result.getBundle()).satisfies(bundleInfo -> {
+                assertThat(bundleInfo.getDelivery_character_type())
+                        .isEqualTo(DeliveryCharacterType.CHARACTER_1.name());
+                assertThat(bundleInfo.getStatus())
+                        .isEqualTo(BundleStatus.PUBLISHED.name());
+                assertThat(bundleInfo.getTotal_gifts()).isEqualTo(1);
+                assertThat(bundleInfo.getGifts()).hasSize(1)
+                        .first()
+                        .satisfies(giftInfo -> {
+                            assertThat(giftInfo.getId()).isEqualTo(gift.getId());
+                            assertThat(giftInfo.getMessage()).isNull();
+                            assertThat(giftInfo.getThumbnail()).isNotNull();
+                            assertThat(giftInfo.getImageUrls()).hasSize(1);
+                        });
+            });
+
+            verify(bundleRepository).findByLink(link);
+            verify(giftRepository).findByBundleId(bundle.getId());
+            verify(giftImageRepository).findByGiftIdIn(any());
+            verify(responseRepository).findAllByBundleIdAndGiftIds(anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 링크로 조회시 예외가 발생한다")
+        void fail_whenInvalidLink() {
+            // given
+            String invalidLink = "invalid-link";
+            when(bundleRepository.findByLink(invalidLink)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> responseService.getBundleByLink(invalidLink))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_LINK);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 보따리 조회시 예외가 발생한다")
+        void fail_whenCompleted() {
+            // given
+            String link = "completed-link";
+            Bundle bundle = createTestBundle(1L, link, BundleStatus.COMPLETED);
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+
+            // when & then
+            assertThatThrownBy(() -> responseService.getBundleByLink(link))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_BUNDLE_STATUS);
+        }
+    }
+}


### PR DESCRIPTION


# Pull Request

## 💡 PR 요약

보따리 조회 API 및 관련 기능을 구현하였습니다.  
- QueryDSL 기반의 데이터 조회 로직을 추가하여, 선물, 이미지, 응답 정보를 통합 조회할 수 있도록 하였습니다.  
- Response 엔티티 및 Repository, 서비스, API 엔드포인트를 구현하고 관련 테스트 클래스도 작성하였습니다.

## 🔍 주요 변경사항

- **QueryDSL 설정 및 의존성 추가:**  
  QueryDSL을 통한 동적 쿼리 지원을 위해 `build.gradle` 파일에 관련 설정과 의존성을 추가하였습니다.

- **응답( Response ) 관련 구현:**  
  - 기존 `GiftResponse` 파일을 제거하고, 새로운 `Response` 엔티티를 도입하였습니다.  
  - 응답 태그 Enum 타입(`ResponseTag`) 및 응답 상태 필드를 추가하였습니다.  
  - Response 리포지토리 인터페이스와 QueryDSL 기반 커스텀 구현체를 정의하였습니다.

- **보따리 조회 기능:**  
  - 보따리 조회 API 엔드포인트를 구현하여, 선물, 이미지, 응답 정보를 통합 조회하는 서비스 로직을 작성하였습니다.  
  - GiftImage 조회 리포지토리에 `findByGiftIdIn` 메서드를 추가하여, 관련 데이터 조회를 지원합니다.

- **테스트 코드:**  
  ResponseService의 기본 테스트 클래스 구조를 구현하여, 향후 테스트 코드 작성의 기반을 마련하였습니다.

## 🔗 연관된 이슈

- 관련 이슈: [[#이슈번호](https://chatgpt.com/c/67af4ee9-4b4c-800c-983b-2d6ffa65af8a#)](#)  
  (실제 이슈 번호가 있다면 링크로 연결해주세요.)

## 📸 스크린샷 (선택)

> UI 변경사항은 없으며, API 응답 결과는 Postman 등으로 확인 가능합니다.  
> 필요 시 테스트 결과 스크린샷을 첨부할 수 있습니다.

## ✅ 체크리스트

- [x] 테스트 코드를 작성하였나요?  
- [x] 관련 문서를 업데이트하였나요?  
- [ ] Breaking Change가 있나요?  
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항



## 📋 추가 컨텍스트 (선택)


