### PR TITLE
[Feature/response-answer] 보따리 답변 기능 구현

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -25,7 +25,6 @@ public enum BaseResponseStatus {
     BUNDLE_DESIGN_REQUIRED(false, 400, "보따리 디자인을 선택하세요."),
     BUNDLE_MINIMUM_GIFTS_REQUIRED(false, 400, "보따리는 최소 2개의 선물을 포함해야 합니다."),
 
-
     BUNDLE_ACCESS_DENIED(false, 403, "보따리 수정 권한이 없습니다."),
     BUNDLE_NOT_FOUND(false, 404, "보따리를 찾을 수 없습니다."),
     INVALID_BUNDLE_STATUS(false, 400, "이미 배달이 시작된 보따리입니다."),
@@ -34,7 +33,13 @@ public enum BaseResponseStatus {
     NOT_DELIVERED_YET(false, 400 ,"아직 배송 상태가 아닙니다" ),
     INVALID_BUNDLE_STATUS_FOR_COMPLETE(false, 400, "PUBLISHED 상태에서만 COMPLETED로 변경 가능합니다."),
 
-
+    /**
+     * 400: Gift Response 관련 오류
+     */
+    ALREADY_ANSWERED(false, 400, "이미 답변이 완료된 보따리입니다."),
+    INCOMPLETE_RESPONSES(false, 400, "모든 선물에 대한 답변이 필요합니다."),
+    INVALID_RESPONSE_TYPE(false, 400, "잘못된 응답 타입입니다."),
+    INVALID_GIFT_ID(false, 400, "존재하지 않는 선물입니다."),
 
     /**
      * 500: Server 오류
@@ -43,6 +48,7 @@ public enum BaseResponseStatus {
     SERVER_ERROR(false, 500, "서버와의 연결에 실패하였습니다."),
     KAKAO_API_ERROR(false, 502, "카카오 API 호출 중 오류가 발생했습니다."),
     INTERNAL_SERVER_ERROR(false, 500, "서버에서 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+
     private final boolean isSuccess;
     private final int code;
     private final String message;

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleDeliveryRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleDeliveryRequest.java
@@ -2,11 +2,15 @@ package com.picktory.domain.bundle.dto;
 
 import com.picktory.domain.bundle.enums.DeliveryCharacterType;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BundleDeliveryRequest {
     @NotNull(message = "배달부 캐릭터를 선택해주세요.")
     private DeliveryCharacterType deliveryCharacterType;

--- a/src/main/java/com/picktory/domain/gift/dto/GiftResponse.java
+++ b/src/main/java/com/picktory/domain/gift/dto/GiftResponse.java
@@ -5,11 +5,13 @@ import com.picktory.domain.gift.entity.GiftImage;
 import com.picktory.domain.gift.enums.GiftResponseTag;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Setter
 @Getter
 @Builder
 public class GiftResponse {

--- a/src/main/java/com/picktory/domain/response/controller/ResponseController.java
+++ b/src/main/java/com/picktory/domain/response/controller/ResponseController.java
@@ -2,20 +2,32 @@ package com.picktory.domain.response.controller;
 
 import com.picktory.common.BaseResponse;
 import com.picktory.domain.response.dto.ResponseBundleDto;
+import com.picktory.domain.response.dto.SaveGiftResponsesRequest;
+import com.picktory.domain.response.dto.SaveGiftResponsesResponse;
 import com.picktory.domain.response.service.ResponseService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/responses")
+@RequestMapping("/api/v1")
 public class ResponseController {
     private final ResponseService responseService;
 
-    @GetMapping("/bundles/{link}")
+    @GetMapping("/responses/bundles/{link}")
     public ResponseEntity<BaseResponse<ResponseBundleDto>> getBundleByLink(@PathVariable String link) {
         ResponseBundleDto response = responseService.getBundleByLink(link);
         return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @PostMapping("/gifts/{link}/answers")
+    public ResponseEntity<BaseResponse<SaveGiftResponsesResponse>> saveGiftResponses(
+            @PathVariable String link,
+            @RequestBody SaveGiftResponsesRequest request) {
+        SaveGiftResponsesResponse response = responseService.saveGiftResponses(link, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new BaseResponse<>(response));
     }
 }

--- a/src/main/java/com/picktory/domain/response/dto/SaveGiftResponsesRequest.java
+++ b/src/main/java/com/picktory/domain/response/dto/SaveGiftResponsesRequest.java
@@ -1,0 +1,20 @@
+package com.picktory.domain.response.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class SaveGiftResponsesRequest {
+    private String bundleId;
+    private List<GiftResponse> gifts;
+
+    @Getter
+    @Setter
+    public static class GiftResponse {
+        private Long giftId;
+        private String responseTag;
+    }
+}

--- a/src/main/java/com/picktory/domain/response/dto/SaveGiftResponsesResponse.java
+++ b/src/main/java/com/picktory/domain/response/dto/SaveGiftResponsesResponse.java
@@ -1,0 +1,18 @@
+package com.picktory.domain.response.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SaveGiftResponsesResponse {
+    private int answeredCount;
+    private int totalCount;
+
+    public static SaveGiftResponsesResponse of(int answeredCount, int totalCount) {
+        return SaveGiftResponsesResponse.builder()
+                .answeredCount(answeredCount)
+                .totalCount(totalCount)
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/response/entity/Response.java
+++ b/src/main/java/com/picktory/domain/response/entity/Response.java
@@ -1,6 +1,7 @@
 package com.picktory.domain.response.entity;
 
 import com.picktory.common.BaseEntity;
+import com.picktory.domain.gift.enums.GiftResponseTag;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,7 +24,7 @@ public class Response extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "response_tag", nullable = false)
-    private ResponseTag responseTag;
+    private GiftResponseTag responseTag;
 
     @Column(columnDefinition = "TEXT")
     private String message;

--- a/src/main/java/com/picktory/domain/response/entity/ResponseTag.java
+++ b/src/main/java/com/picktory/domain/response/entity/ResponseTag.java
@@ -1,9 +1,0 @@
-package com.picktory.domain.response.entity;
-
-public enum ResponseTag {
-    OPTION_1,
-    OPTION_2,
-    OPTION_3,
-    OPTION_4,
-    OPTION_5
-}

--- a/src/main/java/com/picktory/domain/response/repository/ResponseRepository.java
+++ b/src/main/java/com/picktory/domain/response/repository/ResponseRepository.java
@@ -3,6 +3,9 @@ package com.picktory.domain.response.repository;
 import com.picktory.domain.response.entity.Response;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ResponseRepository extends JpaRepository<Response, Long>, ResponseRepositoryCustom {
     boolean existsByGiftId(Long giftId);
+    boolean existsByGiftIdIn(List<Long> giftIds);
 }

--- a/src/test/java/com/picktory/response/service/ResponseServiceTest.java
+++ b/src/test/java/com/picktory/response/service/ResponseServiceTest.java
@@ -9,9 +9,12 @@ import com.picktory.domain.bundle.enums.DesignType;
 import com.picktory.domain.bundle.repository.BundleRepository;
 import com.picktory.domain.gift.entity.Gift;
 import com.picktory.domain.gift.entity.GiftImage;
+import com.picktory.domain.gift.enums.GiftResponseTag;
 import com.picktory.domain.gift.repository.GiftImageRepository;
 import com.picktory.domain.gift.repository.GiftRepository;
 import com.picktory.domain.response.dto.ResponseBundleDto;
+import com.picktory.domain.response.dto.SaveGiftResponsesRequest;
+import com.picktory.domain.response.dto.SaveGiftResponsesResponse;
 import com.picktory.domain.response.entity.Response;
 import com.picktory.domain.response.repository.ResponseRepository;
 import com.picktory.domain.response.service.ResponseService;
@@ -24,8 +27,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -71,25 +76,41 @@ class ResponseServiceTest {
                 .name("테스트 선물")
                 .message("테스트 메시지")
                 .purchaseUrl("http://test.com")
+                .responseTag(GiftResponseTag.GREAT)
                 .isResponsed(false)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    private GiftImage createTestGiftImage(Long giftId, boolean isPrimary) {
+    private GiftImage createTestGiftImage(Long id, Long giftId, String imageUrl, boolean isPrimary) {
         return GiftImage.builder()
-                .id(1L)
+                .id(id)
                 .giftId(giftId)
-                .imageUrl("http://example.com/image.jpg")
+                .imageUrl(imageUrl)
                 .isPrimary(isPrimary)
                 .uploadedAt(LocalDateTime.now())
                 .build();
     }
 
+    private SaveGiftResponsesRequest createTestRequest(Long bundleId, List<Long> giftIds) {
+        List<SaveGiftResponsesRequest.GiftResponse> giftResponses = giftIds.stream()
+                .map(giftId -> {
+                    SaveGiftResponsesRequest.GiftResponse giftResponse = new SaveGiftResponsesRequest.GiftResponse();
+                    giftResponse.setGiftId(giftId);
+                    giftResponse.setResponseTag("GREAT");
+                    return giftResponse;
+                })
+                .collect(Collectors.toList());
+
+        SaveGiftResponsesRequest request = new SaveGiftResponsesRequest();
+        request.setBundleId(bundleId.toString());
+        request.setGifts(giftResponses);
+        return request;
+    }
+
     @Nested
     @DisplayName("선물 보따리 조회")
     class GetBundle {
-
         @Test
         @DisplayName("PUBLISHED 상태의 보따리를 정상적으로 조회할 수 있다")
         void success() {
@@ -97,13 +118,15 @@ class ResponseServiceTest {
             String link = "valid-link";
             Bundle bundle = createTestBundle(1L, link, BundleStatus.PUBLISHED);
             Gift gift = createTestGift(1L, bundle.getId());
-            GiftImage thumbnail = createTestGiftImage(gift.getId(), true);
-            GiftImage additionalImage = createTestGiftImage(gift.getId(), false);
+            List<GiftImage> giftImages = List.of(
+                    createTestGiftImage(1L, gift.getId(), "http://example.com/image1.jpg", true),
+                    createTestGiftImage(2L, gift.getId(), "http://example.com/image2.jpg", false)
+            );
             List<Response> responses = List.of();
 
             when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
             when(giftRepository.findByBundleId(bundle.getId())).thenReturn(List.of(gift));
-            when(giftImageRepository.findByGiftIdIn(any())).thenReturn(List.of(thumbnail, additionalImage));
+            when(giftImageRepository.findByGiftIdIn(any())).thenReturn(giftImages);
             when(responseRepository.findAllByBundleIdAndGiftIds(anyLong(), any())).thenReturn(responses);
 
             // when
@@ -120,9 +143,12 @@ class ResponseServiceTest {
                         .first()
                         .satisfies(giftInfo -> {
                             assertThat(giftInfo.getId()).isEqualTo(gift.getId());
-                            assertThat(giftInfo.getMessage()).isNull();
-                            assertThat(giftInfo.getThumbnail()).isNotNull();
-                            assertThat(giftInfo.getImageUrls()).hasSize(1);
+                            assertThat(giftInfo.getMessage()).isNull(); // 응답되지 않은 선물이므로 메시지는 null
+                            assertThat(giftInfo.getImageUrls())
+                                    .hasSize(1)
+                                    .containsExactly("http://example.com/image2.jpg"); // primary가 아닌 이미지만 포함
+                            assertThat(giftInfo.getThumbnail())
+                                    .isEqualTo("http://example.com/image1.jpg"); // primary 이미지가 thumbnail이 됨
                         });
             });
 
@@ -131,7 +157,6 @@ class ResponseServiceTest {
             verify(giftImageRepository).findByGiftIdIn(any());
             verify(responseRepository).findAllByBundleIdAndGiftIds(anyLong(), any());
         }
-
         @Test
         @DisplayName("존재하지 않는 링크로 조회시 예외가 발생한다")
         void fail_whenInvalidLink() {
@@ -159,4 +184,124 @@ class ResponseServiceTest {
                     .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_BUNDLE_STATUS);
         }
     }
-}
+
+    @Nested
+    @DisplayName("선물 답변 저장")
+    class SaveGiftResponses {
+        @Test
+        @DisplayName("모든 선물에 대한 답변을 정상적으로 저장할 수 있다")
+        void success() {
+            // given
+            String link = "valid-link";
+            Long bundleId = 1L;
+            List<Long> giftIds = List.of(1L, 2L);
+
+            Bundle bundle = createTestBundle(bundleId, link, BundleStatus.PUBLISHED);
+            List<Gift> gifts = giftIds.stream()
+                    .map(id -> createTestGift(id, bundleId))
+                    .toList();
+            SaveGiftResponsesRequest request = createTestRequest(bundleId, giftIds);
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+            when(giftRepository.findByBundleId(bundleId)).thenReturn(gifts);
+            when(responseRepository.existsByGiftIdIn(giftIds)).thenReturn(false);
+            when(bundleRepository.save(any(Bundle.class))).thenReturn(bundle);
+            when(responseRepository.saveAll(any())).thenReturn(List.of());
+
+            // when
+            SaveGiftResponsesResponse response = responseService.saveGiftResponses(link, request);
+
+            // then
+            assertThat(response.getAnsweredCount()).isEqualTo(giftIds.size());
+            assertThat(response.getTotalCount()).isEqualTo(giftIds.size());
+
+            verify(bundleRepository).findByLink(link);
+            verify(giftRepository).findByBundleId(bundleId);
+            verify(responseRepository).existsByGiftIdIn(giftIds);
+            verify(responseRepository).saveAll(any());
+            verify(bundleRepository).save(any(Bundle.class));
+        }
+    }
+        @Test
+        @DisplayName("이미 완료된 보따리에 답변을 저장할 수 없다")
+        void fail_whenAlreadyCompleted() {
+            // given
+            String link = "completed-link";
+            Bundle bundle = createTestBundle(1L, link, BundleStatus.COMPLETED);
+            SaveGiftResponsesRequest request = createTestRequest(bundle.getId(), List.of(1L));
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+
+            // when & then
+            assertThatThrownBy(() -> responseService.saveGiftResponses(link, request))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.ALREADY_ANSWERED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 선물에 대한 답변을 저장할 수 없다")
+        void fail_whenInvalidGiftId() {
+            // given
+            String link = "valid-link";
+            Long bundleId = 1L;
+            List<Long> requestGiftIds = List.of(999L); // 존재하지 않는 선물 ID
+
+            Bundle bundle = createTestBundle(bundleId, link, BundleStatus.PUBLISHED);
+            List<Gift> gifts = List.of(createTestGift(1L, bundleId)); // 실제 존재하는 선물
+            SaveGiftResponsesRequest request = createTestRequest(bundleId, requestGiftIds);
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+            when(giftRepository.findByBundleId(bundleId)).thenReturn(gifts);
+
+            // when & then
+            assertThatThrownBy(() -> responseService.saveGiftResponses(link, request))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INVALID_GIFT_ID);
+        }
+
+        @Test
+        @DisplayName("이미 답변이 있는 선물에 대해 답변을 저장할 수 없다")
+        void fail_whenResponseAlreadyExists() {
+            // given
+            String link = "valid-link";
+            Long bundleId = 1L;
+            List<Long> giftIds = List.of(1L);
+
+            Bundle bundle = createTestBundle(bundleId, link, BundleStatus.PUBLISHED);
+            List<Gift> gifts = List.of(createTestGift(1L, bundleId));
+            SaveGiftResponsesRequest request = createTestRequest(bundleId, giftIds);
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+            when(giftRepository.findByBundleId(bundleId)).thenReturn(gifts);
+            when(responseRepository.existsByGiftIdIn(any())).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> responseService.saveGiftResponses(link, request))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.ALREADY_ANSWERED);
+        }
+
+        @Test
+        @DisplayName("모든 선물에 대한 답변이 없으면 저장할 수 없다")
+        void fail_whenIncompleteResponses() {
+            // given
+            String link = "valid-link";
+            Long bundleId = 1L;
+            List<Long> giftIds = List.of(1L); // 1개의 선물만 답변
+
+            Bundle bundle = createTestBundle(bundleId, link, BundleStatus.PUBLISHED);
+            List<Gift> gifts = List.of(
+                    createTestGift(1L, bundleId),
+                    createTestGift(2L, bundleId) // 2개의 선물이 존재
+            );
+            SaveGiftResponsesRequest request = createTestRequest(bundleId, giftIds);
+
+            when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
+            when(giftRepository.findByBundleId(bundleId)).thenReturn(gifts);
+
+            // when & then
+            assertThatThrownBy(() -> responseService.saveGiftResponses(link, request))
+                    .isInstanceOf(BaseException.class)
+                    .hasFieldOrPropertyWithValue("status", BaseResponseStatus.INCOMPLETE_RESPONSES);
+        }
+    }


### PR DESCRIPTION
# Pull Request
## 💡 PR 요약
선물 보따리 답변 기능 구현: 응답 저장 및 조회 기능
## 🔍 주요 변경사항
- GiftResponseTag로 응답 태그 관리 체계 통합 (ResponseTag 제거)
- 선물 답변 저장 API 및 관련 DTO 구현
  - SaveGiftResponsesRequest, SaveGiftResponsesResponse 추가
  - `/gifts/{link}/answers` POST 엔드포인트 구현
- ResponseService에 다중 선물 답변 처리 로직 추가
  - 번들 상태 검증
  - 선물 목록 검증
  - 기존 응답 여부 검증
  - 모든 선물 응답 완료 여부 검증
- ResponseBundleDto에서 응답된 선물의 메시지 표시 로직 구현
- 테스트 코드 추가 및 개선
  - 선물 답변 저장 성공/실패 케이스 테스트
  - 보따리 조회 테스트 개선

## 🔗 연관된 이슈
선물 보따리 답변 기능 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [x] Breaking Change가 있나요? (ResponseTag enum 제거)
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
