### PR TITLE
보따리 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,13 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
+    implementation 'software.amazon.awssdk:s3:2.27.3'
+    implementation 'software.amazon.awssdk:s3control:2.27.3'
+    implementation 'software.amazon.awssdk:s3outposts:2.27.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/picktory/config/auth/AuthenticationService.java
+++ b/src/main/java/com/picktory/config/auth/AuthenticationService.java
@@ -23,13 +23,16 @@ public class AuthenticationService {
             throw new IllegalStateException(BaseResponseStatus.INVALID_JWT.getMessage());
         }
 
-        // 사용자의 ID가 숫자가 아니라면 Kakao ID로 조회
+        // JWT의 subject 값은 서비스의 userId이므로, 이를 숫자로 변환하여 조회
         String authName = authentication.getName();
         System.out.println("인증된 사용자 ID: " + authName);
 
-        // 만약 `authName`이 숫자가 아닌 경우, Kakao OAuth로 로그인한 사용자로 가정
-        return userRepository.findByKakaoId(authName)
-                .orElseThrow(() -> new IllegalStateException(BaseResponseStatus.USER_NOT_FOUND.getMessage()));
+        try {
+            Long userId = Long.parseLong(authName);
+            return userRepository.findByIdAndIsDeletedFalse(userId)
+                    .orElseThrow(() -> new IllegalStateException(BaseResponseStatus.USER_NOT_FOUND.getMessage()));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("유효하지 않은 사용자 ID입니다.");
+        }
     }
-
 }

--- a/src/main/java/com/picktory/config/s3/S3Config.java
+++ b/src/main/java/com/picktory/config/s3/S3Config.java
@@ -1,0 +1,63 @@
+package com.picktory.config.s3;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+/**
+ * S3Presigner 설정: EC2환경에서는 IAM Role을 기본으로 사용하며, 로컬에선 Access Key 인증
+ */
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.s3.access-key:}")  // 값이 없으면 빈 문자열 반환
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key:}")  // 값이 없으면 빈 문자열 반환
+    private String secretKey;
+
+    /**
+     * S3Presigner Bean 생성 (IAM Role → Access Key 순으로 인증)
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsCredentialsProvider credentialsProvider = getCredentialsProvider();
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    /**
+     * IAM Role이 존재하면 사용, 없으면 Access Key 사용
+     */
+    private AwsCredentialsProvider getCredentialsProvider() {
+        try {
+            // 우선 IAM Role을 사용
+            AwsCredentialsProvider defaultProvider = DefaultCredentialsProvider.create();
+            defaultProvider.resolveCredentials();  // IAM Role이 존재하는지 체크
+            log.info("IAM Role을 사용하여 AWS 인증을 수행합니다.");
+            return defaultProvider;
+        } catch (Exception e) {
+            // IAM Role이 없을 경우 Access Key 사용
+            if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
+                log.warn("IAM Role을 찾을 수 없습니다. Access Key & Secret Key 인증을 사용합니다.");
+                return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+            } else {
+                throw new RuntimeException("AWS 인증 정보를 찾을 수 없습니다. IAM Role 또는 Access Key를 설정하세요.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -80,5 +80,14 @@ public class BundleController {
     ) {
         return ResponseEntity.ok(bundleService.updateDeliveryCharacter(id, request));
     }
+
+    /**
+     * 보따리 삭제 API
+     */
+    @DeleteMapping("/{bundleId}")
+    public ResponseEntity<Void> deleteBundle(@PathVariable Long bundleId) {
+        bundleService.deleteBundle(bundleId);
+        return ResponseEntity.noContent().build(); // 204
+    }
 }
 

--- a/src/main/java/com/picktory/domain/gift/controller/S3Controller.java
+++ b/src/main/java/com/picktory/domain/gift/controller/S3Controller.java
@@ -1,0 +1,39 @@
+package com.picktory.domain.gift.controller;
+
+import com.picktory.domain.gift.dto.s3.PresignedUrlRequest;
+import com.picktory.domain.gift.dto.s3.PresignedUrlResponse;
+import com.picktory.domain.gift.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/gifts/images")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    /**
+     * Presigned URL 생성 API
+     */
+    @PostMapping("/presigned-urls")
+    public ResponseEntity<Map<String, List<PresignedUrlResponse>>> generatePresignedUrls(
+            @Valid @RequestBody PresignedUrlRequest request
+    ) {
+        log.info("Presigned URL 요청 - count: {}, 확장자: {}", request.getCount(), request.getFileExtension());
+
+        // 서비스에서 인증된 사용자 확인 및 Presigned URL 생성
+        List<PresignedUrlResponse> urls = s3Service.generatePresignedUrls(request.getCount(), request.getFileExtension());
+
+        log.info("Presigned URL {}개 생성 완료", urls.size());
+
+        return ResponseEntity.ok(Map.of("presignedUrls", urls));
+    }
+}

--- a/src/main/java/com/picktory/domain/gift/dto/s3/PresignedUrlRequest.java
+++ b/src/main/java/com/picktory/domain/gift/dto/s3/PresignedUrlRequest.java
@@ -1,0 +1,19 @@
+package com.picktory.domain.gift.dto.s3;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PresignedUrlRequest {
+
+    @Min(1)
+    @Max(5)
+    private int count;  // 최소 1개, 최대 5개
+
+    @NotBlank
+    private String fileExtension; // 프론트에서 확장자를 요청하도록 변경
+}

--- a/src/main/java/com/picktory/domain/gift/dto/s3/PresignedUrlResponse.java
+++ b/src/main/java/com/picktory/domain/gift/dto/s3/PresignedUrlResponse.java
@@ -1,0 +1,11 @@
+package com.picktory.domain.gift.dto.s3;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PresignedUrlResponse {
+    private String presignedUrl;
+    private int expiresIn;
+}

--- a/src/main/java/com/picktory/domain/gift/entity/GiftImage.java
+++ b/src/main/java/com/picktory/domain/gift/entity/GiftImage.java
@@ -17,7 +17,7 @@ public class GiftImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY) // 🎯 ManyToOne 단방향 관계 설정
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "gift_id", nullable = false)
     private Gift gift;
 

--- a/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
+++ b/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
@@ -9,10 +9,14 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface GiftImageRepository extends JpaRepository<GiftImage, Long> {
-    List<GiftImage> findByGiftId(Long giftId);
+//    List<GiftImage> findByGiftId(Long giftId);
+    @Query("SELECT gi FROM GiftImage gi WHERE gi.gift.id = :giftId")
+    List<GiftImage> findByGiftId(@Param("giftId") Long giftId);
 
-    List<GiftImage> findByGiftIdIn(List<Long> giftIds);
-
+//    List<GiftImage> findByGiftIdIn(List<Long> giftIds);
+    // giftId 리스트로 조회 (JPQL 적용)
+    @Query("SELECT gi FROM GiftImage gi WHERE gi.gift.id IN :giftIds")
+    List<GiftImage> findByGiftIdIn(@Param("giftIds") List<Long> giftIds);
 
     @Modifying
     @Query("DELETE FROM GiftImage gi WHERE gi.gift.id IN :giftIds")

--- a/src/main/java/com/picktory/domain/gift/service/S3Service.java
+++ b/src/main/java/com/picktory/domain/gift/service/S3Service.java
@@ -1,0 +1,82 @@
+package com.picktory.domain.gift.service;
+
+import com.picktory.config.auth.AuthenticationService;
+import com.picktory.domain.gift.dto.s3.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    private final S3Presigner s3Presigner;
+    private final AuthenticationService authenticationService;
+
+    // 허용된 확장자 목록 (jpg, jpeg, png, webp)
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
+
+    /**
+     * Presigned URL 리스트 생성 요청
+     */
+    public List<PresignedUrlResponse> generatePresignedUrls(int count, String fileExtension) {
+        // 현재 로그인한 사용자 가져오기
+        Long userId = authenticationService.getAuthenticatedUser().getId();
+
+        // 개수 검증
+        if (count < 1 || count > 5) {
+            throw new IllegalArgumentException("이미지 개수는 최소 1개, 최대 5개여야 합니다.");
+        }
+
+        // 확장자 검증
+        final String normalizedExtension = fileExtension.toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(normalizedExtension)) {
+            throw new IllegalArgumentException("지원하지 않는 이미지 확장자입니다: " + normalizedExtension);
+        }
+
+        log.info("S3 Presigned URL {}개 생성 시작 for userId: {}, 확장자: {}", count, userId, normalizedExtension);
+
+        return IntStream.range(0, count)
+                .mapToObj(i -> createPresignedUrl(userId, normalizedExtension))
+                .toList();
+    }
+
+    /**
+     * Presigned URL 생성 로직
+     */
+    private PresignedUrlResponse createPresignedUrl(Long userId, String fileExtension) {
+        // 사용자 ID 기반으로 S3 파일 경로 설정
+        String fileName = String.format("gifts/users/%d/%s.%s", userId, UUID.randomUUID(), fileExtension);
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        // Presigned URL 생성
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(Duration.ofMinutes(20)) // 20분간 유효
+                        .putObjectRequest(objectRequest)
+                        .build()
+        );
+
+        log.info("Presigned URL 생성 완료 - 파일명: {}", fileName);
+
+        return new PresignedUrlResponse(presignedRequest.url().toString(), 1200);
+    }
+}


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 보따리 삭제 구현했습니다.
- 보따리 삭제 시 이 보따리 fk를 가지는 선물이 삭제되며, 선물과 @ManytoOne관계인 선물 이미지도 삭제됩니다.
- 선물 이미지의 경우, S3 저장소에 있는 이미지도 같이 삭제되도록 하는 편이 좋겠지만, 시간상 구현하지 않았고 리팩토링 여지로 남겨두겠습니다.
- @ManytoOne로 인해 GiftImageRepository 오류 발생하여 빌드가 안되길래 코드 수정했으나, 메서드명은 동일하게 유지하여 서비스코드에서의 따로 변경할 필요는 없으니 그대로 풀받아 사용하심됩니다. 

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요? => Postman으로 확인
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
