### PR TITLE
[fix]: 링크 생성 시 "/delivery/" 접두어 제거

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -261,7 +261,7 @@ public class BundleService {
     }
 
     private String generateDeliveryLink() {
-        return "/delivery/" + UUID.randomUUID().toString();
+        return UUID.randomUUID().toString();
     }
 
     private void logGiftDetails(String prefix, Gift gift) {


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 
- 번들 링크 생성 시 불필요한 "/delivery/" 접두어 제거
- 기존 접두어로 인해 API 엔드포인트 경로와 불일치 발생
- API 엔드포인트: /api/v1/responses/bundles/{link}
- 링크 생성 시 UUID 문자열만 반환하도록 수정

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
