### PR TITLE
[feat]: 보따리 간이 조회

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -98,5 +98,14 @@ public class BundleController {
         BundleResultResponse response = bundleService.getBundleResult(id);
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
+
+    /**
+     * 보따리 조회 API (간이 조회)
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<BundleSummaryResponse>> getBundle(@PathVariable Long id) {
+        BundleSummaryResponse response = bundleService.getBundle(id);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
 }
 

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleSummaryResponse.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleSummaryResponse.java
@@ -1,0 +1,41 @@
+package com.picktory.domain.bundle.dto;
+
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.bundle.enums.BundleStatus;
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class BundleSummaryResponse {
+    private Long id;
+    private String name;
+    private String designType;
+    private String status;
+    private String link;
+    private List<GiftThumbnailResponse> gifts;
+
+    public static BundleSummaryResponse fromEntity(Bundle bundle, List<Gift> gifts, List<GiftImage> images) {
+        return BundleSummaryResponse.builder()
+                .id(bundle.getId())
+                .name(bundle.getName())
+                .designType(bundle.getDesignType().name())
+                .status(bundle.getStatus().name())
+                .link(bundle.getStatus() == BundleStatus.DRAFT ? null : bundle.getLink())
+                .gifts(gifts.stream()
+                        .map(gift -> {
+                            GiftImage primaryImage = images.stream()
+                                    .filter(image -> image.getGift().getId().equals(gift.getId()) && image.getIsPrimary())
+                                    .findFirst()
+                                    .orElse(null);
+                            return GiftThumbnailResponse.from(gift, primaryImage);
+                        })
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/bundle/dto/GiftThumbnailResponse.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/GiftThumbnailResponse.java
@@ -1,0 +1,20 @@
+package com.picktory.domain.bundle.dto;
+
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GiftThumbnailResponse {
+    private Long id;
+    private String thumbnail;
+
+    public static GiftThumbnailResponse from(Gift gift, GiftImage primaryImage) {
+        return GiftThumbnailResponse.builder()
+                .id(gift.getId())
+                .thumbnail(primaryImage != null ? primaryImage.getImageUrl() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -284,7 +284,7 @@ public class BundleService {
     /**
      * 보따리 조회 API (간이 조회)
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public BundleSummaryResponse getBundle(Long bundleId) {
         User currentUser = authenticationService.getAuthenticatedUser();
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 보따리 간이 조회 api 개발했습니다. 보따리 결과 조회와 크게 다르지 않았습니다.

> 
> # 11. 보따리 간이 조회 API
> GET /api/v1/bundles/{id}
> 
> ### 설명
> - 특정 보따리의 정보를 간이 조회하는 API
> - 보따리의 이름(name), 디자인 타입(designType), 상태(status), 배달 링크(link) 포함
> - 보따리에 포함된 선물 목록과 각 선물의 대표 이미지(썸네일) 제공
> - 보따리 상태가 `DRAFT`일 경우 `link`는 `null`
> - 각 선물의 `isPrimary = true`인 `GiftImage.imageUrl`을 썸네일로 제공
> - 인증된 사용자만 사용 가능 (Authorization 헤더 필요)
> (백엔드에서 status=COMPLETED(답변 완료된 보따리)상태일 때 사용자가 이 API 최초 호출 시, isRead=true로 변경함)
> 


## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)
<img width="869" alt="스크린샷 2025-02-16 오후 7 04 28" src="https://github.com/user-attachments/assets/76c1fcaf-e8a5-498c-875c-d92c39839d94" />


> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
-> 보따리 상태가 DRAFT여서 Link가 null인 경우, 이외 상태라서 링크가 있는 경우, status=COMPLETED(답변 완료된 보따리)상태일 때 사용자가 이 API 최초 호출 시, isRead=true로 변경되는 경우 모두 Postman으로 확인했습니다.
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
