### PR TITLE
[Feature/individual-gift-inquiry] : 보따리 개별 조회 기능 구현

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -41,6 +41,13 @@ public enum BaseResponseStatus {
     INVALID_RESPONSE_TYPE(false, 400, "잘못된 응답 타입입니다."),
     INVALID_GIFT_ID(false, 400, "존재하지 않는 선물입니다."),
 
+
+    /**
+     * 404: Gift 관련 오류
+     */
+    GIFT_NOT_FOUND(false, 404, "해당 선물을 찾을 수 없습니다."),
+
+
     /**
      * 500: Server 오류
      */

--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -10,6 +10,7 @@ import com.picktory.domain.bundle.dto.BundleResponse;
 import com.picktory.domain.bundle.dto.BundleUpdateRequest;
 
 import com.picktory.domain.bundle.service.BundleService;
+import com.picktory.domain.gift.dto.GiftDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -98,5 +99,17 @@ public class BundleController {
         BundleResultResponse response = bundleService.getBundleResult(id);
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
+
+    /**
+     * 보따리 개별 선물 조회 API
+     */
+    @GetMapping("/{bundleId}/gifts/{giftId}")
+    public ResponseEntity<GiftDetailResponse> getGift(
+            @PathVariable Long bundleId,
+            @PathVariable Long giftId
+    ) {
+        return ResponseEntity.ok(bundleService.getGift(bundleId, giftId));
+    }
+
 }
 

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -340,4 +340,23 @@ public class BundleService {
         log.debug("{} - [id: {}] name: {}, message: {}, purchaseUrl: {}",
                 prefix, gift.getId(), gift.getName(), gift.getMessage(), gift.getPurchaseUrl());
     }
+    /**
+     * 보따리 개별 선물 조회
+     */
+    @Transactional(readOnly = true)
+    public GiftDetailResponse getGift(Long bundleId, Long giftId) {
+        User currentUser = authenticationService.getAuthenticatedUser();
+
+        // 보따리 존재 및 권한 확인
+        Bundle bundle = validateAndGetBundle(bundleId, currentUser);
+
+        // 선물 조회
+        Gift gift = giftRepository.findByIdAndBundleId(giftId, bundleId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.GIFT_NOT_FOUND));
+
+        // 이미지 조회
+        List<GiftImage> images = giftImageRepository.findByGiftId(giftId);
+
+        return GiftDetailResponse.fromEntity(gift, images);
+    }
 }

--- a/src/main/java/com/picktory/domain/gift/dto/GiftDetailResponse.java
+++ b/src/main/java/com/picktory/domain/gift/dto/GiftDetailResponse.java
@@ -1,0 +1,44 @@
+package com.picktory.domain.gift.dto;
+
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GiftDetailResponse {
+    private Long id;
+    private String name;
+    private String message;
+    private String purchaseUrl;
+    private String thumbnail;    // isPrimary = true인 이미지
+    private List<String> imageUrls;  // isPrimary = false인 이미지들
+
+    public static GiftDetailResponse fromEntity(Gift gift, List<GiftImage> images) {
+        // 대표 이미지(썸네일) 찾기
+        String thumbnail = images.stream()
+                .filter(GiftImage::getIsPrimary)
+                .findFirst()
+                .map(GiftImage::getImageUrl)
+                .orElse(null);
+
+        // 나머지 이미지들
+        List<String> imageUrls = images.stream()
+                .filter(image -> !image.getIsPrimary())
+                .map(GiftImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        return GiftDetailResponse.builder()
+                .id(gift.getId())
+                .name(gift.getName())
+                .message(gift.getMessage())
+                .purchaseUrl(gift.getPurchaseUrl())
+                .thumbnail(thumbnail)
+                .imageUrls(imageUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/gift/repository/GiftRepository.java
+++ b/src/main/java/com/picktory/domain/gift/repository/GiftRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GiftRepository extends JpaRepository<Gift, Long> {
     List<Gift> findByBundleId(Long bundleId);
@@ -15,4 +16,5 @@ public interface GiftRepository extends JpaRepository<Gift, Long> {
     @Query("DELETE FROM Gift g WHERE g.id IN :giftIds")
     void deleteByIds(@Param("giftIds") List<Long> giftIds);
 
+    Optional<Gift> findByIdAndBundleId(Long id, Long bundleId);
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
보따리 개별 선물 조회 API를 구현했습니다. 특정 보따리에 포함된 개별 선물을 조회할 수 있으며, 선물의 기본 정보와 함께 대표 이미지(썸네일)와 추가 이미지 목록을 제공합니다.

## 🔍 주요 변경사항
- GiftDetailResponse DTO 생성 (썸네일과 이미지 목록 분리)
- GiftRepository에 findByIdAndBundleId 메서드 추가
- BaseResponseStatus에 GIFT_NOT_FOUND 에러 코드 추가
- BundleController에 개별 선물 조회 API 엔드포인트 추가
- BundleService에 개별 선물 조회 로직 구현
- 상세 단위 테스트 케이스 추가

## 🔗 연관된 이슈
보따리 개별 선물 조회 API 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
  - 성공 케이스, 권한 없음, 리소스 없음 등 모든 시나리오 테스트 완료
- [x] 관련 문서를 업데이트하였나요?
  - API 문서에 새로운 엔드포인트 정보 추가
- [ ] Breaking Change가 있나요?
  - 없음
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?
  - 완료

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
