### PR TITLE
[Feature/bundle-draft-gifts]: 보따리 마저 채우기 기능 구현

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -10,6 +10,7 @@ import com.picktory.domain.bundle.dto.BundleResponse;
 import com.picktory.domain.bundle.dto.BundleUpdateRequest;
 
 import com.picktory.domain.bundle.service.BundleService;
+import com.picktory.domain.gift.dto.DraftGiftsResponse;
 import com.picktory.domain.gift.dto.GiftDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -111,5 +112,12 @@ public class BundleController {
         return ResponseEntity.ok(bundleService.getGift(bundleId, giftId));
     }
 
+    /**
+     * 임시 저장된 보따리의 선물 목록 조회 API
+     */
+    @GetMapping("/{id}/gifts")
+    public ResponseEntity<DraftGiftsResponse> getDraftGifts(@PathVariable Long id) {
+        return ResponseEntity.ok(bundleService.getDraftGifts(id));
+    }
 }
 

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -359,4 +359,31 @@ public class BundleService {
 
         return GiftDetailResponse.fromEntity(gift, images);
     }
+
+
+    /**
+     * 임시 저장된 보따리의 선물 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public DraftGiftsResponse getDraftGifts(Long bundleId) {
+        User currentUser = authenticationService.getAuthenticatedUser();
+
+        // 보따리 존재 및 권한 확인
+        Bundle bundle = validateAndGetBundle(bundleId, currentUser);
+
+        // DRAFT 상태 확인
+        if (bundle.getStatus() != BundleStatus.DRAFT) {
+            throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS);
+        }
+
+        // 선물 목록 조회
+        List<Gift> gifts = giftRepository.findByBundleId(bundleId);
+
+        // 선물 이미지 조회
+        List<GiftImage> images = giftImageRepository.findByGiftIds(
+                gifts.stream().map(Gift::getId).collect(Collectors.toList())
+        );
+
+        return DraftGiftsResponse.from(gifts, images);
+    }
 }

--- a/src/main/java/com/picktory/domain/gift/dto/DraftGiftsResponse.java
+++ b/src/main/java/com/picktory/domain/gift/dto/DraftGiftsResponse.java
@@ -1,0 +1,60 @@
+package com.picktory.domain.gift.dto;
+
+import com.picktory.domain.gift.entity.Gift;
+import com.picktory.domain.gift.entity.GiftImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class DraftGiftsResponse {
+    private List<GiftDetailResponse> gifts;
+
+    public static DraftGiftsResponse from(List<Gift> gifts, List<GiftImage> images) {
+        // 선물 ID별로 이미지 그룹화
+        Map<Long, List<GiftImage>> giftImagesMap = images.stream()
+                .collect(Collectors.groupingBy(
+                        image -> image.getGift().getId()
+                ));
+
+        // 각 선물에 대한 DetailResponse 생성
+        List<GiftDetailResponse> giftResponses = gifts.stream()
+                .map(gift -> {
+                    // 해당 선물의 이미지 목록 가져오기
+                    List<GiftImage> giftImages = giftImagesMap.getOrDefault(gift.getId(), Collections.emptyList());
+
+                    // 대표 이미지(썸네일) 찾기
+                    String thumbnail = giftImages.stream()
+                            .filter(GiftImage::getIsPrimary)
+                            .findFirst()
+                            .map(GiftImage::getImageUrl)
+                            .orElse(null);
+
+                    // 나머지 이미지 URL 목록
+                    List<String> imageUrls = giftImages.stream()
+                            .filter(image -> !image.getIsPrimary())
+                            .map(GiftImage::getImageUrl)
+                            .collect(Collectors.toList());
+
+                    // GiftDetailResponse 생성
+                    return GiftDetailResponse.builder()
+                            .id(gift.getId())
+                            .name(gift.getName())
+                            .message(gift.getMessage())
+                            .purchaseUrl(gift.getPurchaseUrl())
+                            .thumbnail(thumbnail)
+                            .imageUrls(imageUrls)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return DraftGiftsResponse.builder()
+                .gifts(giftResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
+++ b/src/main/java/com/picktory/domain/gift/repository/GiftImageRepository.java
@@ -27,4 +27,6 @@ public interface GiftImageRepository extends JpaRepository<GiftImage, Long> {
     @Query("SELECT gi FROM GiftImage gi WHERE gi.gift.id = :giftId AND gi.isPrimary = true")
     Optional<GiftImage> findPrimaryImageByGiftId(@Param("giftId") Long giftId);
 
+    @Query("SELECT gi FROM GiftImage gi WHERE gi.gift.id IN :giftIds")
+    List<GiftImage> findByGiftIds(@Param("giftIds") List<Long> giftIds);
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
임시 저장된 보따리(DRAFT 상태)의 선물 목록을 조회하는 API를 구현했습니다. 해당 API는 선물의 기본 정보와 함께 대표 이미지(썸네일) 및 추가 이미지 목록을 제공합니다.

## 🔍 주요 변경사항
- DraftGiftsResponse DTO 구현
  - 선물 목록과 각 선물별 이미지 정보를 효율적으로 매핑
  - 썸네일과 일반 이미지 구분 처리
- GiftImageRepository에 벌크 이미지 조회 메서드 추가
  - N+1 문제 해결을 위한 findByGiftIds 메서드 구현
- BundleController/Service에 임시 저장 선물 목록 조회 API 추가
  - DRAFT 상태 검증 로직 구현
  - 권한 검증 및 예외 처리
- 단위 테스트 케이스 추가
  - 성공/실패 시나리오 테스트 구현

## 🔗 연관된 이슈
임시 저장된 보따리 선물 목록 조회 API 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
  - 성공 케이스, DRAFT 상태 검증, 권한 검증 등 테스트 완료
- [x] 관련 문서를 업데이트하였나요?
  - API 문서에 새로운 엔드포인트 정보 추가
- [ ] Breaking Change가 있나요?
  - 없음
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?
  - 완료

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
