### PR TITLE
[fix]: 보따리 design_type 필드 추가

### DIFF
--- a/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
+++ b/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
@@ -18,6 +18,7 @@ public class ResponseBundleDto {
     public static class BundleInfo {
         private String delivery_character_type;
         private String status;
+        private String design_type;
         private List<GiftInfo> gifts;
         private int total_gifts;
     }
@@ -57,6 +58,7 @@ public class ResponseBundleDto {
         return ResponseBundleDto.builder()
                 .bundle(BundleInfo.builder()
                         .delivery_character_type(bundle.getDeliveryCharacterType().name())
+                        .design_type(bundle.getDesignType().name())
                         .status(bundle.getStatus().name())
                         .gifts(giftInfos)
                         .total_gifts(gifts.size())

--- a/src/test/java/com/picktory/response/service/ResponseServiceTest.java
+++ b/src/test/java/com/picktory/response/service/ResponseServiceTest.java
@@ -136,6 +136,8 @@ class ResponseServiceTest {
             assertThat(result.getBundle()).satisfies(bundleInfo -> {
                 assertThat(bundleInfo.getDelivery_character_type())
                         .isEqualTo(DeliveryCharacterType.CHARACTER_1.name());
+                assertThat(bundleInfo.getDesign_type())
+                        .isEqualTo(DesignType.RED.name());
                 assertThat(bundleInfo.getStatus())
                         .isEqualTo(BundleStatus.PUBLISHED.name());
                 assertThat(bundleInfo.getTotal_gifts()).isEqualTo(1);


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
보따리 조회 API 응답에 design_type 필드를 추가하여 배달부 SVG 변경에 필요한 보따리 색상 정보를 제공합니다.

## 🔍 주요 변경사항
- ResponseBundleDto.BundleInfo에 design_type 필드 추가
- fromEntity 메서드에서 Bundle의 designType을 ResponseBundleDto에 매핑하는 로직 구현
- ResponseServiceTest에 design_type 필드 반환값 검증 로직 추가

## 🔗 연관된 이슈
보따리 조회 기능 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- ResponseBundleDto에 design_type 필드 추가로 인한 API 응답 변경사항을 확인해주세요
- 테스트 코드의 검증 로직이 적절한지 리뷰 부탁드립니다

## 📋 추가 컨텍스트
해당 PR은 배달부 SVG가 보따리 색상에 따라 동적으로 변경되어야 하는 요구사항을 반영하기 위한 작업입니다. 기존 Bundle 엔티티에 있던 designType 정보를 API 응답에 포함시켜 프론트엔드에서 활용할 수 있도록 구현하였습니다.