### PR TITLE
[refactor]: 보따리 조회 응답 데이터 수정

### DIFF
--- a/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
+++ b/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
@@ -28,28 +28,30 @@ public class ResponseBundleDto {
         private Long id;
         private String message;
         private List<String> imageUrls;
+        private String name;
         private String thumbnail;
     }
 
     public static ResponseBundleDto fromEntity(Bundle bundle, List<Gift> gifts, List<GiftImage> images) {
         List<GiftInfo> giftInfos = gifts.stream()
                 .map(gift -> {
+                    // 해당 선물의 이미지들 찾기
                     List<GiftImage> giftImages = images.stream()
                             .filter(img -> img.getGiftId().equals(gift.getId()))
                             .collect(Collectors.toList());
 
+                    // 이미지가 있는 경우 첫 번째 이미지를 썸네일로 사용
+                    String thumbnail = giftImages.isEmpty() ? null :
+                            giftImages.get(0).getImageUrl();
+
                     return GiftInfo.builder()
                             .id(gift.getId())
-                            .message(null) // 선물이 열리기 전에는 null
+                            .name(gift.getName())  // name 필드 추가
+                            .message(null)
                             .imageUrls(giftImages.stream()
-                                    .filter(img -> !img.getIsPrimary())
                                     .map(GiftImage::getImageUrl)
                                     .collect(Collectors.toList()))
-                            .thumbnail(giftImages.stream()
-                                    .filter(GiftImage::getIsPrimary)
-                                    .findFirst()
-                                    .map(GiftImage::getImageUrl)
-                                    .orElse(null))
+                            .thumbnail(thumbnail)
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/src/test/java/com/picktory/response/service/ResponseServiceTest.java
+++ b/src/test/java/com/picktory/response/service/ResponseServiceTest.java
@@ -82,11 +82,11 @@ class ResponseServiceTest {
                 .build();
     }
 
-    private GiftImage createTestGiftImage(Long id, Long giftId, String imageUrl, boolean isPrimary) {
+    private GiftImage createTestGiftImage(Long giftId, boolean isPrimary) {
         return GiftImage.builder()
-                .id(id)
-                .giftId(giftId)
-                .imageUrl(imageUrl)
+                .id(1L)  // 테스트용 고정 ID
+                .giftId(giftId)  // Gift ID 설정
+                .imageUrl("http://example.com/image.jpg")  // 테스트용 고정 URL
                 .isPrimary(isPrimary)
                 .uploadedAt(LocalDateTime.now())
                 .build();
@@ -118,15 +118,13 @@ class ResponseServiceTest {
             String link = "valid-link";
             Bundle bundle = createTestBundle(1L, link, BundleStatus.PUBLISHED);
             Gift gift = createTestGift(1L, bundle.getId());
-            List<GiftImage> giftImages = List.of(
-                    createTestGiftImage(1L, gift.getId(), "http://example.com/image1.jpg", true),
-                    createTestGiftImage(2L, gift.getId(), "http://example.com/image2.jpg", false)
-            );
+            GiftImage thumbnail = createTestGiftImage(gift.getId(), true);
+            GiftImage additionalImage = createTestGiftImage(gift.getId(), false);
             List<Response> responses = List.of();
 
             when(bundleRepository.findByLink(link)).thenReturn(Optional.of(bundle));
             when(giftRepository.findByBundleId(bundle.getId())).thenReturn(List.of(gift));
-            when(giftImageRepository.findByGiftIdIn(any())).thenReturn(giftImages);
+            when(giftImageRepository.findByGiftIdIn(any())).thenReturn(List.of(thumbnail, additionalImage));
             when(responseRepository.findAllByBundleIdAndGiftIds(anyLong(), any())).thenReturn(responses);
 
             // when
@@ -143,12 +141,11 @@ class ResponseServiceTest {
                         .first()
                         .satisfies(giftInfo -> {
                             assertThat(giftInfo.getId()).isEqualTo(gift.getId());
-                            assertThat(giftInfo.getMessage()).isNull(); // 응답되지 않은 선물이므로 메시지는 null
-                            assertThat(giftInfo.getImageUrls())
-                                    .hasSize(1)
-                                    .containsExactly("http://example.com/image2.jpg"); // primary가 아닌 이미지만 포함
-                            assertThat(giftInfo.getThumbnail())
-                                    .isEqualTo("http://example.com/image1.jpg"); // primary 이미지가 thumbnail이 됨
+                            assertThat(giftInfo.getName()).isEqualTo(gift.getName());  // name 검증 추가
+                            assertThat(giftInfo.getMessage()).isNull();
+                            assertThat(giftInfo.getThumbnail()).isNotNull();
+                            assertThat(giftInfo.getImageUrls()).hasSize(2);  // 모든 이미지 URL 포함되는지 검증
+                            assertThat(giftInfo.getImageUrls()).contains(thumbnail.getImageUrl());  // 썸네일 URL 포함 검증
                         });
             });
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
보따리 조회 API 응답 데이터 구조 개선

## 🔍 주요 변경사항
- 선물 name 필드 추가
- 썸네일 이미지를 imageUrls에도 포함하도록 수정
- 첫 번째 이미지를 썸네일로 사용하도록 변경
- 관련 테스트 코드 수정

## 🔗 연관된 이슈
#28 보따리 조회 기능 구현

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
- 프론트엔드팀의 요청사항을 반영하여 이미지 URL 처리 로직을 수정했습니다
- 기존 isPrimary 플래그는 유지하되 실제 동작은 첫 번째 이미지를 썸네일로 사용하도록 변경했습니다