### PR TITLE
S3 이미지 조회 시 cloudfront(CDN)사용

### DIFF
--- a/src/main/java/com/picktory/config/s3/S3Config.java
+++ b/src/main/java/com/picktory/config/s3/S3Config.java
@@ -25,6 +25,9 @@ public class S3Config {
     @Value("${aws.s3.secret-key:}")
     private String secretKey;
 
+    @Value("${aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
     /**
      * S3Client Bean 생성 (IAM Role → Access Key 순으로 인증)
      */

--- a/src/main/java/com/picktory/domain/gift/service/S3Service.java
+++ b/src/main/java/com/picktory/domain/gift/service/S3Service.java
@@ -29,6 +29,10 @@ public class S3Service {
     @Value("${aws.s3.region}")
     private String region;
 
+    @Value("${aws.cloudfront.domain}")
+    private String cloudFrontDomain;
+
+
     private final S3Client s3Client;
     private final AuthenticationService authenticationService;
 
@@ -102,7 +106,8 @@ public class S3Service {
      * DB에 저장될 S3 접근 가능한 URL 생성
      */
     private String getFileUrl(String filePath) {
-        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, filePath);
+//        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, filePath);
+        return String.format("https://%s/%s", cloudFrontDomain, filePath);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> S3 이미지 조회 시 cloudfront(CDN)사용하도록 수정했습니다.
지금은 이미지 URL에 S3 버킷명이 그대로 노출되고 있는데,
사용자가 S3 이미지 주소에 다이렉트로 접근해서 버킷명이 노출되면 DDoS 공격 등에 위험하고, 과금도 쉽게 돼
보통은 중간에 CloudFront 같은 CDN을 프록시처럼 두고 이미지 조회를 처리하는 게 일반적이라고 알고 있습니다.
이렇게 하면 S3 버킷명을 숨길 수 있고, 성능 최적화(DDoS 방어 포함)에도 유리해요. 특히 트래픽이 많아질 경우 CloudFront가 캐싱 역할을 해서 S3 직접 접근보다 속도도 빨라지고 비용도 절감할 수 있다고 하여 수정했습니다.

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요? => Postman 로컬 테스트 완료.
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
