### PR TITLE
[fix]: 보따리 조회 API 접근 403 에러 해결

### DIFF
--- a/src/main/java/com/picktory/config/SecurityConfig.java
+++ b/src/main/java/com/picktory/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                 "/favicon.ico",
                 "/default-ui.css",
                 "/kakao/callback",
+                API_V1 + "gifts/{link}/**",
                 API_V1 + "oauth/login",
                 API_V1 + "auth/backup/signup",
                 API_V1 + "auth/backup/login",

--- a/src/main/java/com/picktory/config/SecurityConfig.java
+++ b/src/main/java/com/picktory/config/SecurityConfig.java
@@ -85,11 +85,11 @@ public class SecurityConfig {
                 "/favicon.ico",
                 "/default-ui.css",
                 "/kakao/callback",
-                API_V1 + "gifts/{link}/**",
                 API_V1 + "oauth/login",
                 API_V1 + "auth/backup/signup",
                 API_V1 + "auth/backup/login",
-                API_V1 + "gifts/{link}/**"
+                API_V1 + "gifts/{link}/**",
+                API_V1 + "responses/bundles/**"
         };
     }
 

--- a/src/main/java/com/picktory/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/picktory/config/jwt/JwtAuthenticationFilter.java
@@ -41,8 +41,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/kakao/callback") ||
                 path.equals("/favicon.ico") ||
-                path.equals("/default-ui.css");
-
+                path.equals("/default-ui.css") ||
+                path.startsWith("/api/v1/responses/bundles/") ||
+                path.startsWith("/api/v1/gifts/");
         log.debug("Should not filter request: {}", shouldNotFilter);
         return shouldNotFilter;
     }


### PR DESCRIPTION
# Pull Request

## 🔗 연관된 기능
- 구현 기능: 비회원 보따리 조회 API 접근 허용

## 📝 작업 내용
- 구현 내용:
  - 비회원이 공유 링크를 통해 보따리를 조회할 수 있도록 인증 로직 수정
  - SecurityConfig 및 JwtAuthenticationFilter에 보따리 조회 API 경로 추가
- 변경 사항:
  - SecurityConfig의 getPublicEndpoints()에 "/api/v1/responses/bundles/**" 경로 추가
  - JwtAuthenticationFilter의 shouldNotFilter()에 해당 경로 추가

## ✅ 테스트 결과
- [x] 로컬 테스트 완료
- [x] 단위 테스트 통과

### 테스트 상세 내용
- 테스트 환경: 로컬
- 테스트 결과:
  - 공유 링크를 통한 보따리 접근 시 403 에러 해결
  - 비회원 상태에서 정상적으로 API 응답 확인

## 🚨 주의사항
- API 문서상 "비회원도 접근 가능한 공개 API"로 명시되어 있어 인증 없이 접근 가능하도록 수정

## 🙏 리뷰 요청사항
- 리뷰 포인트:
