### PR TITLE
[fix]: 보따리 마저 채우기 API 썸네일 로직 통일

### DIFF
--- a/src/main/java/com/picktory/domain/gift/dto/DraftGiftsResponse.java
+++ b/src/main/java/com/picktory/domain/gift/dto/DraftGiftsResponse.java
@@ -28,16 +28,12 @@ public class DraftGiftsResponse {
                     // 해당 선물의 이미지 목록 가져오기
                     List<GiftImage> giftImages = giftImagesMap.getOrDefault(gift.getId(), Collections.emptyList());
 
-                    // 대표 이미지(썸네일) 찾기
-                    String thumbnail = giftImages.stream()
-                            .filter(GiftImage::getIsPrimary)
-                            .findFirst()
-                            .map(GiftImage::getImageUrl)
-                            .orElse(null);
+                    // 이미지가 있는 경우 첫 번째 이미지를 썸네일로 사용
+                    String thumbnail = giftImages.isEmpty() ? null :
+                            giftImages.get(0).getImageUrl();
 
-                    // 나머지 이미지 URL 목록
+                    // 모든 이미지 URL 목록
                     List<String> imageUrls = giftImages.stream()
-                            .filter(image -> !image.getIsPrimary())
                             .map(GiftImage::getImageUrl)
                             .collect(Collectors.toList());
 


### PR DESCRIPTION
# Pull Request
## 💡 PR 요약
보따리 마저 채우기 API와 보따리 조회 API 간 썸네일 처리 로직 통일

## 🔍 주요 변경사항
- `DraftGiftsResponse` 클래스에서 썸네일 결정 로직 변경 (첫 번째 이미지를 썸네일로 사용)
- 모든 이미지 URL을 `imageUrls`에 포함하도록 수정

## 🔗 연관된 이슈


## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- PR #45에서 구현된 `DraftGiftsResponse` 클래스의 썸네일 처리 로직을 PR #51의 방식과 일치시켰습니다
- 기존 `isPrimary` 플래그는 그대로 유지했지만 실제 동작은 첫 번째 이미지를 썸네일로 사용합니다
- 테스트 코드는 이미 PR #51 방식으로 구현되어 있어 추가 수정은 불필요했습니다

## 📋 추가 컨텍스트
- 이 변경으로 보따리 관련 모든 API에서 일관된 응답 형식을 유지할 수 있게 됩니다
- 프론트엔드와의 인터페이스 일관성을 위해 필요한 변경입니다