### PR TITLE
[fix]: 보따리 풀어보기 API 응답에 보따리 ID 추가

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -381,7 +381,7 @@ public class BundleService {
         log.info("보따리 삭제 완료 - bundleId: {}", bundleId);
     }
 
-     /**
+    /**
      * 보따리 결과 조회
      */
     public BundleResultResponse getBundleResult(Long bundleId) {
@@ -493,6 +493,7 @@ public class BundleService {
         log.debug("{} - [id: {}] name: {}, message: {}, purchaseUrl: {}",
                 prefix, gift.getId(), gift.getName(), gift.getMessage(), gift.getPurchaseUrl());
     }
+
     /**
      * 보따리 개별 선물 조회
      */
@@ -537,6 +538,6 @@ public class BundleService {
                 gifts.stream().map(Gift::getId).collect(Collectors.toList())
         );
 
-        return DraftGiftsResponse.from(gifts, images);
+        return DraftGiftsResponse.from(bundle, gifts, images);  // Bundle 객체 전달
     }
 }

--- a/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
+++ b/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
@@ -16,6 +16,7 @@ public class ResponseBundleDto {
     @Getter
     @Builder
     public static class BundleInfo {
+        private Long id;
         private String delivery_character_type;
         private String status;
         private String design_type;
@@ -59,6 +60,7 @@ public class ResponseBundleDto {
 
         return ResponseBundleDto.builder()
                 .bundle(BundleInfo.builder()
+                        .id(bundle.getId())
                         .delivery_character_type(bundle.getDeliveryCharacterType().name())
                         .design_type(bundle.getDesignType().name())
                         .status(bundle.getStatus().name())


### PR DESCRIPTION
# Pull Request
## 💡 PR 요약
보따리 조회 API 응답에 보따리 ID를 추가하여 답변 저장하기 API와의 연동을 개선했습니다.

## 🔍 주요 변경사항
- ResponseBundleDto에 bundle.id 필드 추가

## 🔗 연관된 이슈
#42 - 답변 저장하기 API 연동 이슈

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- ResponseBundleDto 구조에 ID 필드만 추가했으므로 기존 로직에 영향이 없습니다
- API 문서도 함께 업데이트했으니 확인 부탁드립니다
