### PR TITLE
메인 보따리 조회 시 isRead필드 COMPLETED&&!false만 false로 반환

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/dto/BundleMainListResponse.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleMainListResponse.java
@@ -1,6 +1,7 @@
 package com.picktory.domain.bundle.dto;
 
 import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.bundle.enums.BundleStatus;
 import com.picktory.domain.bundle.enums.DesignType;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class BundleMainListResponse {
                 .name(bundle.getName())
                 .designType(bundle.getDesignType())
                 .updatedAt(bundle.getUpdatedAt())
-                .isRead(bundle.getIsRead())
+                .isRead(bundle.getStatus() == BundleStatus.COMPLETED && !bundle.getIsRead() ? false : true)
                 .build();
     }
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 프론트 요청으로, 메인 보따리 조회 시 isRead필드 COMPLETED&&!false만 false로 반환으로 급히 수정합니다. 나머지는 true로 반환하는 것으로 수정함.

## 🔍 주요 변경사항

> 구체적인 변경 내용을 설명해주세요
> - 변경사항 1
> - 변경사항 2
> - 변경사항 3

## 🔗 연관된 이슈

> 관련 이슈를 링크해주세요 (예: #이슈번호)

## 📸 스크린샷 (선택)

> UI 변경사항이 있다면 스크린샷을 첨부해주세요

## ✅ 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [ ] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> 예시:
> - 특정 로직에 대한 의견이 필요합니다
> - 성능 개선 방안에 대한 피드백 부탁드립니다
> - 더 나은 네이밍 제안이 있다면 알려주세요

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
