### PR TITLE
[hotfix]: jwt 엑세스 토큰 시간 변경

### DIFF
--- a/src/main/java/com/picktory/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/picktory/config/jwt/JwtTokenProvider.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final Key key;
-    private final long VALID_MILISECOND = 1000L * 60 * 60; // 1시간
+    private final long VALID_MILISECOND = 1000L * 60 * 60 * 24; // 24시간
     private static final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24; // 24시간
     private static final String BEARER_PREFIX = "Bearer ";
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> jwt 엑세스 토큰 시간을 1-> 24시간으로 변경함.
만료되었을 때 자동으로 refreshToken 사용해서 다시 accessToken 재발급받는 api가 현재 없고, accessToken 만료 시 따로 로그아웃되지 않고 있어 토큰 만료 시간을 늘림.
