### PR TITLE
[feat]: BaseException 전역 예외 처리 로직 추가 - BaseResponse 형식으로 일관된 에러 응답 반환

### DIFF
--- a/src/main/java/com/picktory/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/picktory/common/error/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.picktory.common.error.handler;
 
 import com.picktory.common.BaseResponse;
 import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -56,5 +57,17 @@ public class GlobalExceptionHandler {
         log.error("서버 오류 발생: ", ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR));
+    }
+
+
+    /**
+     * BaseException (커스텀 예외) 처리
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<BaseResponse<?>> handleBaseException(BaseException e) {
+        log.warn("BaseException 발생: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getStatus().getCode())  // 예외에 지정된 HTTP 상태 코드 반환
+                .body(new BaseResponse<>(e.getStatus()));
     }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 기존 GlobalExceptionHandler가 서비스 로직에서 예외 발생시 메시지를 같이 반환하지 않는 부분이 있어서 추가했습니다
