### PR TITLE
[refactor]: 인증 관련 예외 처리를 BaseException으로 통일

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -14,7 +14,11 @@ public enum BaseResponseStatus {
     /**
      * 400: Client 오류 (잘못된 요청)
      */
+    INVALID_USER_ID(false, 401, "유효하지 않은 사용자 ID입니다."),
+    INVALID_ACCESS_TOKEN(false, 401, "액세스 토큰이 비어있습니다."),
+    INVALID_REFRESH_TOKEN(false, 401, "리프레시 토큰이 비어있습니다."),
     INVALID_JWT(false, 401, "유효하지 않은 JWT입니다."),
+    EXPIRED_REFRESHTOKEN(false, 401, "리프레시 토큰이 만료됐으니, 다시 로그인해주세요."),
     INVALID_USER_JWT(false, 403, "권한이 없는 유저의 접근입니다."),
     USER_NOT_FOUND(false, 404, "존재하지 않는 유저입니다."),
     FORBIDDEN(false, 403, "이 리소스에 대한 접근 권한이 없습니다."),

--- a/src/main/java/com/picktory/config/auth/AuthenticationService.java
+++ b/src/main/java/com/picktory/config/auth/AuthenticationService.java
@@ -1,8 +1,9 @@
 package com.picktory.config.auth;
 
+import com.picktory.common.exception.BaseException;
+import com.picktory.common.BaseResponseStatus;
 import com.picktory.domain.user.entity.User;
 import com.picktory.domain.user.repository.UserRepository;
-import com.picktory.common.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,7 +21,7 @@ public class AuthenticationService {
     public User getAuthenticatedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
-            throw new IllegalStateException(BaseResponseStatus.INVALID_JWT.getMessage());
+            throw new BaseException(BaseResponseStatus.INVALID_JWT);
         }
 
         // JWT의 subject 값은 서비스의 userId이므로, 이를 숫자로 변환하여 조회
@@ -30,9 +31,9 @@ public class AuthenticationService {
         try {
             Long userId = Long.parseLong(authName);
             return userRepository.findByIdAndIsDeletedFalse(userId)
-                    .orElseThrow(() -> new IllegalStateException(BaseResponseStatus.USER_NOT_FOUND.getMessage()));
+                    .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
         } catch (NumberFormatException e) {
-            throw new IllegalStateException("유효하지 않은 사용자 ID입니다.");
+            throw new BaseException(BaseResponseStatus.INVALID_USER_ID);
         }
     }
 }

--- a/src/main/java/com/picktory/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/picktory/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.picktory.domain.auth.controller;
 
+import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
 import com.picktory.common.BaseResponse;
 import com.picktory.domain.user.dto.UserLoginRequest;
 import com.picktory.domain.user.dto.UserLoginResponse;
@@ -28,9 +30,18 @@ public class AuthController {
      */
     @PostMapping("/oauth/login")
     public ResponseEntity<BaseResponse<UserLoginResponse>> login(@RequestBody UserLoginRequest request) {
-        log.info("Login request received with code");
-        UserLoginResponse response = authService.loginWithKakao(request.getCode());
-        return ResponseEntity.ok(BaseResponse.success(response, "로그인 성공"));
+        try {
+            log.info("Login request received with code");
+            UserLoginResponse response = authService.loginWithKakao(request.getCode());
+            return ResponseEntity.ok(BaseResponse.success(response, "로그인 성공"));
+        } catch (BaseException e) {
+            return ResponseEntity.status(e.getStatus().getCode())
+                    .body(new BaseResponse<>(e.getStatus()));
+        } catch (Exception e) {
+            log.error("Login error:", e);
+            return ResponseEntity.internalServerError()
+                    .body(new BaseResponse<>(BaseResponseStatus.SERVER_ERROR));
+        }
     }
 
     /**
@@ -41,8 +52,17 @@ public class AuthController {
      */
     @PostMapping("/auth/refresh")
     public ResponseEntity<BaseResponse<UserLoginResponse>> refreshToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        log.info("Token refresh request received");
-        UserLoginResponse response = authService.refreshToken(refreshToken);
-        return ResponseEntity.ok(BaseResponse.success(response, "토큰 갱신 성공"));
+        try {
+            log.info("Token refresh request received");
+            UserLoginResponse response = authService.refreshToken(refreshToken);
+            return ResponseEntity.ok(BaseResponse.success(response, "토큰 갱신 성공"));
+        } catch (BaseException e) {
+            return ResponseEntity.status(e.getStatus().getCode())
+                    .body(new BaseResponse<>(e.getStatus()));
+        } catch (Exception e) {
+            log.error("Token refresh error:", e);
+            return ResponseEntity.internalServerError()
+                    .body(new BaseResponse<>(BaseResponseStatus.SERVER_ERROR));
+        }
     }
 }

--- a/src/main/java/com/picktory/domain/auth/dto/TokenDto.java
+++ b/src/main/java/com/picktory/domain/auth/dto/TokenDto.java
@@ -1,5 +1,7 @@
 package com.picktory.domain.auth.dto;
 
+import com.picktory.common.exception.BaseException;
+import com.picktory.common.BaseResponseStatus;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.StringUtils;
@@ -28,10 +30,10 @@ public class TokenDto {
 
     public void validate() {
         if (!StringUtils.hasText(accessToken)) {
-            throw new IllegalArgumentException("Access Token cannot be empty");
+            throw new BaseException(BaseResponseStatus.INVALID_ACCESS_TOKEN);
         }
         if (!StringUtils.hasText(refreshToken)) {
-            throw new IllegalArgumentException("Refresh Token cannot be empty");
+            throw new BaseException(BaseResponseStatus.INVALID_REFRESH_TOKEN);
         }
     }
 }

--- a/src/main/java/com/picktory/domain/auth/oauth/client/KakaoClient.java
+++ b/src/main/java/com/picktory/domain/auth/oauth/client/KakaoClient.java
@@ -1,5 +1,7 @@
 package com.picktory.domain.auth.oauth.client;
 
+import com.picktory.common.exception.BaseException;
+import com.picktory.common.BaseResponseStatus;
 import com.picktory.domain.auth.oauth.dto.KakaoTokenResponse;
 import com.picktory.domain.auth.oauth.dto.KakaoUserInfo;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +42,7 @@ public class KakaoClient {
      *
      * @param code 카카오 인증 코드
      * @return 카카오 액세스 토큰
-     * @throws IllegalStateException 토큰 요청 중 오류 발생 시
+     * @throws BaseException 토큰 요청 중 오류 발생 시
      */
     public String getKakaoAccessToken(String code) {
         log.debug("Requesting Kakao access token with code: {}", code);
@@ -65,7 +67,7 @@ public class KakaoClient {
 
             if (response.getBody() == null || response.getBody().getAccess_token() == null) {
                 log.error("Failed to get Kakao access token: empty response");
-                throw new IllegalStateException("카카오 로그인 처리 중 오류가 발생했습니다.");
+                throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
             }
 
             return response.getBody().getAccess_token();
@@ -73,10 +75,12 @@ public class KakaoClient {
         } catch (HttpClientErrorException e) {
             log.error("Kakao token error - Status: {}, Response: {}",
                     e.getStatusCode(), e.getResponseBodyAsString());
-            throw new IllegalStateException("다시 로그인해 주세요.");
+            throw new BaseException(BaseResponseStatus.INVALID_JWT);
+        } catch (BaseException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to get Kakao access token", e);
-            throw new IllegalStateException("카카오 로그인 처리 중 오류가 발생했습니다.");
+            throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
         }
     }
 
@@ -85,7 +89,7 @@ public class KakaoClient {
      *
      * @param accessToken 카카오 액세스 토큰
      * @return 카카오 사용자 정보
-     * @throws IllegalStateException 사용자 정보 요청 중 오류 발생 시
+     * @throws BaseException 사용자 정보 요청 중 오류 발생 시
      */
     public KakaoUserInfo getKakaoUserInfo(String accessToken) {
         try {
@@ -104,7 +108,7 @@ public class KakaoClient {
 
             if (response.getBody() == null) {
                 log.error("Kakao user info response is empty");
-                throw new IllegalStateException("카카오 API 오류가 발생했습니다.");
+                throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
             }
 
             log.info("카카오 유저 정보를 성공적으로 받음");
@@ -113,10 +117,12 @@ public class KakaoClient {
         } catch (HttpClientErrorException e) {
             log.error("Failed to get Kakao user info - Status: {}, Response: {}",
                     e.getStatusCode(), e.getResponseBodyAsString());
-            throw new IllegalStateException("카카오 사용자 정보 조회 중 오류가 발생했습니다.");
+            throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
+        } catch (BaseException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Unexpected error while getting Kakao user info", e);
-            throw new IllegalStateException("카카오 사용자 정보 조회 중 오류가 발생했습니다.");
+            throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
         }
     }
 
@@ -124,7 +130,7 @@ public class KakaoClient {
      * 카카오 계정 연결 해제를 요청합니다.
      *
      * @param kakaoId 카카오 사용자 ID
-     * @throws IllegalStateException 연결 해제 중 오류 발생 시
+     * @throws BaseException 연결 해제 중 오류 발생 시
      */
     public void unlinkKakaoAccount(Long kakaoId) {
         try {
@@ -145,7 +151,7 @@ public class KakaoClient {
 
         } catch (Exception e) {
             log.error("Failed to unlink Kakao account: {}", kakaoId, e);
-            throw new IllegalStateException("카카오 계정 연결 해제 중 오류가 발생했습니다.");
+            throw new BaseException(BaseResponseStatus.KAKAO_API_ERROR);
         }
     }
 }

--- a/src/main/java/com/picktory/domain/auth/refresh/service/RefreshTokenService.java
+++ b/src/main/java/com/picktory/domain/auth/refresh/service/RefreshTokenService.java
@@ -1,5 +1,7 @@
 package com.picktory.domain.auth.refresh.service;
 
+import com.picktory.common.exception.BaseException;
+import com.picktory.common.BaseResponseStatus;
 import com.picktory.domain.auth.refresh.entity.RefreshToken;
 import com.picktory.domain.auth.refresh.repository.RefreshTokenRepository;
 import com.picktory.domain.auth.refresh.dto.RefreshTokenResponse;
@@ -36,7 +38,7 @@ public class RefreshTokenService {
     public RefreshToken createRefreshToken(Long userId, String token, LocalDateTime expiryDate) {
         // 사용자 존재 여부 확인
         userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.USER_NOT_FOUND));
 
         log.debug("Creating or updating refresh token for user: {}", userId);
 
@@ -84,13 +86,13 @@ public class RefreshTokenService {
      *
      * @param token 확인할 리프레시 토큰 엔티티
      * @return 유효한 리프레시 토큰 엔티티
-     * @throws IllegalStateException 토큰이 만료된 경우
+     * @throws BaseException 토큰이 만료된 경우
      */
     @Transactional
     public RefreshToken verifyExpiration(RefreshToken token) {
         if (token.isExpired()) {
             refreshTokenRepository.delete(token);
-            throw new IllegalStateException("Refresh token was expired. Please make a new signin request");
+            throw new BaseException(BaseResponseStatus.EXPIRED_REFRESHTOKEN);
         }
         return token;
     }

--- a/src/main/java/com/picktory/domain/user/entity/User.java
+++ b/src/main/java/com/picktory/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.picktory.domain.user.entity;
 
 import com.picktory.common.BaseEntity;
+import com.picktory.common.exception.BaseException;
+import com.picktory.common.BaseResponseStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,7 +39,7 @@ public class User extends BaseEntity {
 
     public void delete() {
         if (this.isDeleted) {
-            throw new IllegalStateException("이미 탈퇴한 사용자입니다.");
+            throw new BaseException(BaseResponseStatus.ALREADY_DELETED_USER);
         }
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
인증 관련 예외 처리를 BaseException으로 통일하여 일관된 에러 처리 시스템 구축

## 🔍 주요 변경사항
- IllegalStateException, IllegalArgumentException 등을 BaseException으로 변경
- 에러 응답을 BaseResponseStatus 열거형으로 표준화
- 토큰 만료 예외 처리를 위한 EXPIRED_REFRESHTOKEN 상태 추가
- 에러 메시지 한글화 및 일관성 유지


## 🔗 연관된 이슈
#67 리프레시 토큰 예외 처리 개선

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- AuthService, RefreshTokenService 등의 모든 예외를 BaseException을 통해 표준화했습니다.
- 기존 코드와의 호환성을 위해 BaseResponse를 이용한 응답 형식을 유지했습니다.
- 토큰 만료시 프론트엔드에서 재로그인 요청을 해야함을 명확히 알 수 있도록 메시지를 수정했습니다.


## 📋 추가 컨텍스트
리프레시 토큰 관련 플로우:
1. 리프레시 토큰 만료 시 → EXPIRED_REFRESHTOKEN 예외 발생 → 재로그인 요청
2. 리프레시 토큰 검증 실패 시 → INVALID_JWT 예외 발생
3. 사용자를 찾을 수 없을 때 → USER_NOT_FOUND 예외 발생
