### PR TITLE
[refactor]: ResponseBundleDto 필드 카멜 케이스 네이밍 적용

### DIFF
--- a/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
+++ b/src/main/java/com/picktory/domain/response/dto/ResponseBundleDto.java
@@ -17,11 +17,11 @@ public class ResponseBundleDto {
     @Builder
     public static class BundleInfo {
         private Long id;
-        private String delivery_character_type;
+        private String deliveryCharacterType;
         private String status;
-        private String design_type;
+        private String designType;
         private List<GiftInfo> gifts;
-        private int total_gifts;
+        private int totalGifts;
     }
 
     @Getter
@@ -49,7 +49,7 @@ public class ResponseBundleDto {
 
                     return GiftInfo.builder()
                             .id(gift.getId())
-                            .name(gift.getName())  // name 필드 추가
+                            .name(gift.getName())
                             .message(gift.getMessage())
                             .imageUrls(giftImages.stream()
                                     .map(GiftImage::getImageUrl)
@@ -63,11 +63,11 @@ public class ResponseBundleDto {
         return ResponseBundleDto.builder()
                 .bundle(BundleInfo.builder()
                         .id(bundle.getId())
-                        .delivery_character_type(bundle.getDeliveryCharacterType().name())
-                        .design_type(bundle.getDesignType().name())
+                        .deliveryCharacterType(bundle.getDeliveryCharacterType().name()) // 필드명 변경
+                        .designType(bundle.getDesignType().name()) // 필드명 변경
                         .status(bundle.getStatus().name())
                         .gifts(giftInfos)
-                        .total_gifts(gifts.size())
+                        .totalGifts(gifts.size()) // 필드명 변경
                         .build())
                 .build();
     }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

`ResponseBundleDto` 내 필드명을 스네이크 케이스에서 카멜 케이스로 변경하여 Java 네이밍 컨벤션을 준수하도록 리팩토링했습니다.

## 🔍 주요 변경사항

- `delivery_character_type` → `deliveryCharacterType`
- `design_type` → `designType`
- `total_gifts` → `totalGifts`
- `fromEntity` 메서드 내 필드 매핑 로직 수정
- `ResponseBundleDto` 전체적으로 카멜 케이스 적용

## 🔗 연관된 이슈

> 없음 (또는 관련 이슈가 있다면 여기에 기재)

## 📸 스크린샷 (선택)

> UI 변경사항 없음

## ✅ 체크리스트

- [x] 로컬 테스트 완료
- [ ] 단위 테스트 통과
- [ ] E2E 테스트 통과 (해당되는 경우)
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

- Java 코드 스타일에 맞게 필드명을 통일하였으며, 기존에 API 응답과 불일치하던 네이밍 이슈를 해소하였습니다.

## 📋 추가 컨텍스트 (선택)

