### PR TITLE
[test]: 카카오 클라이언트 테스트 예외 타입 수정

### DIFF
--- a/src/test/java/com/picktory/user/service/KakaoClientTest.java
+++ b/src/test/java/com/picktory/user/service/KakaoClientTest.java
@@ -1,5 +1,7 @@
 package com.picktory.user.service;
 
+import com.picktory.common.BaseResponseStatus;
+import com.picktory.common.exception.BaseException;
 import com.picktory.domain.auth.oauth.dto.KakaoTokenResponse;
 import com.picktory.domain.auth.oauth.dto.KakaoUserInfo;
 import com.picktory.domain.auth.oauth.client.KakaoClient;
@@ -98,11 +100,10 @@ class KakaoClientTest {
         )).thenReturn(responseEntity);
 
         // 실행 및 예외 검증
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+        BaseException exception = assertThrows(BaseException.class, () -> {
             kakaoClient.getKakaoAccessToken(code);
         });
-
-        assertThat(exception.getMessage()).contains("카카오 로그인 처리 중 오류가 발생했습니다");
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.KAKAO_API_ERROR);
     }
 
     /**
@@ -122,11 +123,10 @@ class KakaoClientTest {
         )).thenThrow(httpError);
 
         // 실행 및 예외 검증
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+        BaseException exception = assertThrows(BaseException.class, () -> {
             kakaoClient.getKakaoAccessToken(code);
         });
-
-        assertThat(exception.getMessage()).contains("다시 로그인해 주세요");
+        assertThat(exception.getStatus()).isEqualTo(BaseResponseStatus.INVALID_JWT);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 🔗 연관된 기능
- 구현 기능: 카카오 클라이언트 테스트 수정

## 📝 작업 내용
- 구현 내용:
  - KakaoClientTest 클래스의 예외 처리 로직 수정
  - IllegalStateException에서 BaseException으로 예외 타입 변경
  - 예외 메시지 검증 대신 BaseResponseStatus 검증으로 수정
  
- 변경 사항:
  - testGetKakaoAccessToken_EmptyResponse() 테스트 로직 수정
  - testGetKakaoAccessToken_HttpError() 테스트 로직 수정
  - KAKAO_API_ERROR 및 INVALID_JWT 상태 코드 검증 추가

## ✅ 테스트 결과
- [x] 로컬 테스트 완료
- [x] 단위 테스트 통과

### 테스트 상세 내용
- 테스트 환경: 로컬
- 테스트 결과: KakaoClientTest 관련 테스트 모두 통과

## 🚨 주의사항
- 실제 구현은 변경하지 않고 테스트 코드만 수정했습니다

## 🙏 리뷰 요청사항
