### PR TITLE
[CI/CD] develop 브랜치 push 시 api.picktory.net 자동 배포 설정

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,31 @@
+name: Deploy to api
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+
+      - name: Deploy to API server
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          script: |
+            cd ~/dnd-12th-5-backend
+            git fetch origin
+            git reset --hard origin/develop
+            git clean -fd
+            ./gradlew clean build -x test
+            cp build/libs/picktory-0.0.1-SNAPSHOT.jar /home/ec2-user/picktory-prod.jar
+            sudo systemctl restart picktory.service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,27 @@
-name: Deploy to EC2  # Workflow 이름
-
-on:
-  push:
-    branches:
-      - main  # main 브랜치에 push될 때 실행
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          script: |
-            cd ~/dnd-12th-5-backend
-            git pull origin main
-            ./gradlew build -x test
-            sudo systemctl restart picktory
-
+#name: Deploy to EC2  # Workflow 이름
+#
+#on:
+#  push:
+#    branches:
+#      - main  # main 브랜치에 push될 때 실행
+#
+#jobs:
+#  deploy:
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v3
+#
+#      - name: Deploy to EC2
+#        uses: appleboy/ssh-action@v0.1.7
+#        with:
+#          host: ${{ secrets.EC2_HOST }}
+#          username: ${{ secrets.EC2_USER }}
+#          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+#          script: |
+#            cd ~/dnd-12th-5-backend
+#            git pull origin main
+#            ./gradlew build -x test
+#            sudo systemctl restart picktory
+#


### PR DESCRIPTION
기존 main 브랜치에 push될 때 개발용 API 서버(dev-api.picktory.net)로 자동 배포되던 deploy.yml은 주석 처리했습니다.

대신, 새로운 워크플로우 파일인 deploy-api.yml을 추가하여,
develop 브랜치에 push될 때 개발용 API 서버(api.picktory.net, picktory.service)에 자동 배포되도록 설정했습니다.

앞으로는 develop 브랜치에서 개발하고, 이 브랜치에 push하면 개발용 API 서버가 자동으로 갱신됩니다.

운영용 서비스(dev-api.picktory.net, picktory-dev.service)는 여전히 main 브랜치를 통해 관리되며,
main 브랜치에 push되더라도 자동 배포는 발생하지 않습니다.