### PR TITLE
[fix]: Bundle 생성 시 최소 선물 개수 요구사항 변경

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -27,7 +27,7 @@ public enum BaseResponseStatus {
     BUNDLE_DAILY_LIMIT_EXCEEDED(false, 400, "하루에 최대 10개의 보따리만 생성할 수 있습니다."),
     BUNDLE_NAME_REQUIRED(false, 400, "보따리 이름을 입력하세요."),
     BUNDLE_DESIGN_REQUIRED(false, 400, "보따리 디자인을 선택하세요."),
-    BUNDLE_MINIMUM_GIFTS_REQUIRED(false, 400, "보따리는 최소 2개의 선물을 포함해야 합니다."),
+    BUNDLE_MINIMUM_GIFTS_REQUIRED(false, 400, "보따리는 최소 1개의 선물을 포함해야 합니다."),
     GIFT_IMAGE_REQUIRED(false, 400, "선물에는 이미지가 최소 1장 포함되어야 합니다."),
     INVALID_JSON_REQUEST(false, 400, "잘못된 JSON 형식입니다."),
     INVALID_DESIGN_TYPE(false, 400, "유효하지 않은 디자인 타입입니다. 가능한 값: RED, GREEN, YELLOW, PINK, BLUE"),

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleRequest.java
@@ -28,7 +28,7 @@ public class BundleRequest {
     private DesignType designType;
 
     @NotNull
-    @Size(min = 2, max = 6, message = "보따리에는 최소 2개, 최대 6개의 선물을 담아야 합니다.")
+    @Size(min = 1, max = 6, message = "보따리에는 최소 1개, 최대 6개의 선물을 담아야 합니다.")
     private List<GiftRequest> gifts;
 
     public Bundle toEntity(User user) {

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleUpdateRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleUpdateRequest.java
@@ -16,7 +16,7 @@ public class BundleUpdateRequest {
     @NotNull
     private Long bundleId;
 
-    @NotEmpty(message = "보따리에 포함될 선물 리스트는 최소 2개 이상이어야 합니다.")
+    @NotEmpty(message = "보따리에 포함될 선물 리스트는 최소 1개 이상이어야 합니다.")
     @Size(max = 6, message = "보따리에는 최대 6개의 선물만 포함될 수 있습니다.")
     private List<GiftUpdateRequest> gifts;
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
Bundle 생성 시 최소 선물 개수 요구사항을 완화하는 작업을 수행했습니다.

## 🔍 주요 변경사항
- BundleRequest DTO의 gifts 필드 최소 개수 제한을 1개로 변경
- 보따리(Bundle)에 최소 1개, 최대 6개의 선물 담을 수 있도록 수정
- 유효성 검사 메시지 업데이트

## 🔗 연관된 이슈


## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
이 변경은 사용자 피드백을 반영한 것으로, 보따리 생성 시 선물을 더 적게 담을 수 있도록 하여 사용자 경험을 개선하였습니다. 