### PR TITLE
[feat]: 보따리 이름 수정 API 추가

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -132,5 +132,17 @@ public class BundleController {
         BundleSummaryResponse response = bundleService.getBundle(id);
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
+
+   /**
+     * 보따리 이름 업데이트 API
+     */
+    @PatchMapping("/{bundleId}")
+    public ResponseEntity<BaseResponse<BundleResponse>> updateBundleName(
+            @PathVariable Long bundleId,
+            @Valid @RequestBody BundleNameUpdateRequest request
+    ) {
+        BundleResponse response = bundleService.updateBundleName(bundleId, request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
 }
 

--- a/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
+++ b/src/main/java/com/picktory/domain/bundle/controller/BundleController.java
@@ -2,6 +2,7 @@ package com.picktory.domain.bundle.controller;
 
 import com.picktory.common.BaseResponse;
 
+import com.picktory.common.BaseResponseStatus;
 import com.picktory.config.auth.AuthenticationService;
 import com.picktory.domain.bundle.dto.*;
 
@@ -136,13 +137,13 @@ public class BundleController {
    /**
      * 보따리 이름 업데이트 API
      */
-    @PatchMapping("/{bundleId}")
-    public ResponseEntity<BaseResponse<BundleResponse>> updateBundleName(
-            @PathVariable Long bundleId,
-            @Valid @RequestBody BundleNameUpdateRequest request
-    ) {
-        BundleResponse response = bundleService.updateBundleName(bundleId, request);
-        return ResponseEntity.ok(new BaseResponse<>(response));
-    }
+   @PatchMapping("/{bundleId}")
+   public ResponseEntity<BaseResponse<Void>> updateBundleName(
+           @PathVariable Long bundleId,
+           @Valid @RequestBody BundleNameUpdateRequest request
+   ) {
+       bundleService.updateBundleName(bundleId, request);
+       return ResponseEntity.ok(new BaseResponse<>(BaseResponseStatus.SUCCESS));
+   }
 }
 

--- a/src/main/java/com/picktory/domain/bundle/dto/BundleNameUpdateRequest.java
+++ b/src/main/java/com/picktory/domain/bundle/dto/BundleNameUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.picktory.domain.bundle.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BundleNameUpdateRequest {
+    @NotBlank(message = "보따리 이름은 필수입니다.")
+    @Size(max = 100, message = "보따리 이름은 최대 100자까지 입력할 수 있습니다.")
+    private String name;
+}

--- a/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
+++ b/src/main/java/com/picktory/domain/bundle/entity/Bundle.java
@@ -111,4 +111,14 @@ public class Bundle extends BaseEntity {
             throw new BaseException(BaseResponseStatus.INVALID_CHARACTER_TYPE);
         }
     }
+
+    /**
+     * 보따리의 이름을 업데이트
+     */
+    public void updateName(String name) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new BaseException(BaseResponseStatus.BUNDLE_NAME_REQUIRED);
+        }
+        this.name = name;
+    }
 }

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -283,27 +283,17 @@ public class BundleService {
     }
 
     @Transactional
-    public BundleResponse updateBundleName(Long bundleId, BundleNameUpdateRequest request) {
-        log.info("보따리 이름 업데이트 요청: bundleId = {}", bundleId);
-
+    public void updateBundleName(Long bundleId, BundleNameUpdateRequest request) {
         User currentUser = authenticationService.getAuthenticatedUser();
         Bundle bundle = validateAndGetBundle(bundleId, currentUser);
 
-        // DRAFT 상태가 아니면 이름 변경 불가
+        // DRAFT 상태 검증
         if (bundle.getStatus() != BundleStatus.DRAFT) {
             throw new BaseException(BaseResponseStatus.INVALID_BUNDLE_STATUS_FOR_DRAFT);
         }
 
         // 이름 업데이트
         bundle.updateName(request.getName());
-        Bundle savedBundle = bundleRepository.save(bundle);
-
-        // 기존 선물 및 이미지 조회
-        List<Gift> savedGifts = giftService.getGiftsByBundleId(bundleId);
-        List<GiftImage> savedImages = giftService.getImagesByGiftIds(
-                savedGifts.stream().map(Gift::getId).toList()
-        );
-
-        return BundleResponse.fromEntity(savedBundle, savedGifts, savedImages);
+        bundleRepository.save(bundle);
     }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
보따리 이름만 수정할 수 있는 새로운 PATCH API를 구현했습니다. 기존 PUT API는 선물 목록 수정 용도로 남겨두고, 이름 수정은 별도 API로 분리하여 효율성을 개선했습니다.

## 🔍 주요 변경사항
- PATCH `/api/v1/bundles/{bundleId}` 엔드포인트 구현
- 보따리 이름만 수정하기 위한 `BundleNameUpdateRequest` DTO 생성
- `BundleController`에 이름 수정 메소드 추가
- `BundleService`에 이름 수정 로직 구현


## 🔗 연관된 이슈
관련 이슈 없음

## ✅ 체크리스트
- [ ] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항

## 📋 추가 컨텍스트
이 변경은 보따리 이름만 수정하고 싶을 때 불필요하게 전체 선물 리스트를 요청에 포함시켜야 하는 문제를 해결합니다. 보따리 상태가 DRAFT일 때만 이름 수정이 가능하도록 제한했습니다.