### PR TITLE
[fix]: 회원 탈퇴 후 재가입 오류 수정

### DIFF
--- a/src/main/java/com/picktory/domain/auth/service/AuthService.java
+++ b/src/main/java/com/picktory/domain/auth/service/AuthService.java
@@ -139,7 +139,10 @@ public class AuthService {
                 .map(foundUser -> {
                     log.info("Found existing user: {}", foundUser.getId());
                     if (foundUser.isDeleted()) {
-                        throw new BaseException(BaseResponseStatus.ALREADY_DELETED_USER);
+                        // 탈퇴한 사용자 재활성화
+                        log.info("Reactivating deleted user: {}", foundUser.getId());
+                        foundUser.reactivate();
+                        return userRepository.save(foundUser);
                     }
                     return foundUser;
                 })

--- a/src/main/java/com/picktory/domain/user/entity/User.java
+++ b/src/main/java/com/picktory/domain/user/entity/User.java
@@ -45,4 +45,9 @@ public class User extends BaseEntity {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void reactivate() {
+        this.isDeleted = false;
+        this.deletedAt = null;
+    }
 }


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약
회원 탈퇴 후 재가입 시 발생하던 오류를 수정했습니다.

## 🔍 주요 변경사항
- AuthService에서 탈퇴한 사용자 재가입 시 410 에러 발생하던 문제 해결
- isDeleted 상태인 사용자도 재활성화할 수 있도록 로직 변경
- User 엔티티에 reactivate() 메서드 추가

## 🔗 연관된 이슈
-

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [ ] 테스트 코드를 작성하였나요?
- [ ] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항
- 기존에는 탈퇴한 사용자가 재가입을 시도하면 `ALREADY_DELETED_USER` 예외가 발생했습니다.
- 이를 수정하여 탈퇴한 사용자도 재활성화될 수 있도록 변경했습니다.
- 향후 탈퇴 정책이 구체화되면 추가 수정이 필요할 수 있습니다.

## 📋 추가 컨텍스트 (선택)
프론트엔드에서 회원 탈퇴 후 재가입 시도 시 `axios.ts:9 Axios error [410]: 이미 탈퇴한 유저입니다.` 에러가 발생하던 문제를 해결합니다. 서비스 초기 단계이므로 일단 재가입이 가능하도록 처리했습니다.