### PR TITLE
[feat]: 설문조사 응답 제출 & 설문조사 대상 확인 API 구현

### DIFF
--- a/src/main/java/com/picktory/common/BaseResponseStatus.java
+++ b/src/main/java/com/picktory/common/BaseResponseStatus.java
@@ -53,6 +53,7 @@ public enum BaseResponseStatus {
     INVALID_GIFT_ID(false, 400, "존재하지 않는 선물입니다."),
     INVALID_GIFT_UPDATE(false,400,"요청 사항이 비어있습니다."),
 
+    INVALID_SURVEY_SATISFACTION(false, 400, "유효하지 않은 설문 응답값입니다. 가능한 값: GOOD, SOSO, BAD"),
 
     /**
      * 404: Gift 관련 오류

--- a/src/main/java/com/picktory/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/picktory/common/error/handler/GlobalExceptionHandler.java
@@ -27,6 +27,9 @@ public class GlobalExceptionHandler {
         if (ex.getMessage().contains("com.picktory.domain.bundle.enums.DesignType")) {
             return ResponseEntity.badRequest().body(new BaseResponse<>(BaseResponseStatus.INVALID_DESIGN_TYPE));
         }
+        if (ex.getMessage().contains("com.picktory.domain.survey.enums.SurveySatisfaction")) {
+            return ResponseEntity.badRequest().body(new BaseResponse<>(BaseResponseStatus.INVALID_SURVEY_SATISFACTION));
+        }
 
         return ResponseEntity.badRequest().body(new BaseResponse<>(BaseResponseStatus.INVALID_JSON_REQUEST));
     }

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
@@ -29,4 +29,6 @@ public interface BundleRepository extends JpaRepository<Bundle, Long> {
 
 
     Optional<Bundle> findByIdAndStatus(Long id, BundleStatus status);
+
+    long countByUserId(Long userId);
 }

--- a/src/main/java/com/picktory/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/picktory/domain/survey/controller/SurveyController.java
@@ -1,0 +1,34 @@
+package com.picktory.domain.survey.controller;
+
+import com.picktory.common.BaseResponse;
+import com.picktory.config.auth.AuthenticationService;
+import com.picktory.domain.survey.dto.SurveyRequest;
+import com.picktory.domain.survey.dto.SurveyResponse;
+import com.picktory.domain.survey.service.SurveyService;
+import com.picktory.domain.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/surveys")
+@RequiredArgsConstructor
+public class SurveyController {
+    private final SurveyService surveyService;
+    private final AuthenticationService authenticationService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<SurveyResponse>> submitSurvey(@Valid @RequestBody SurveyRequest request) {
+        User currentUser = authenticationService.getAuthenticatedUser();
+        SurveyResponse response = surveyService.submitSurvey(currentUser.getId(), request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new BaseResponse<>(true, 201, "설문 응답이 성공적으로 저장되었습니다.", response));
+
+    }
+}

--- a/src/main/java/com/picktory/domain/survey/dto/SurveyRequest.java
+++ b/src/main/java/com/picktory/domain/survey/dto/SurveyRequest.java
@@ -1,0 +1,13 @@
+package com.picktory.domain.survey.dto;
+
+import com.picktory.domain.survey.enums.SurveySatisfaction;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SurveyRequest {
+
+    @NotNull(message = "설문 만족도가 선택되지 않았습니다.")
+    private SurveySatisfaction surveySatisfaction;
+
+}

--- a/src/main/java/com/picktory/domain/survey/dto/SurveyResponse.java
+++ b/src/main/java/com/picktory/domain/survey/dto/SurveyResponse.java
@@ -1,0 +1,12 @@
+package com.picktory.domain.survey.dto;
+
+import com.picktory.domain.survey.enums.SurveySatisfaction;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SurveyResponse {
+    private Long surveyId;
+    private SurveySatisfaction satisfaction;
+}

--- a/src/main/java/com/picktory/domain/survey/entity/Survey.java
+++ b/src/main/java/com/picktory/domain/survey/entity/Survey.java
@@ -1,0 +1,36 @@
+package com.picktory.domain.survey.entity;
+
+import com.picktory.common.BaseEntity;
+import com.picktory.domain.survey.enums.SurveySatisfaction;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "surveys")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Survey extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SurveySatisfaction surveySatisfaction;
+
+
+    private Survey(Long userId, SurveySatisfaction satisfaction) {
+        this.userId = userId;
+        this.surveySatisfaction = satisfaction;
+    }
+
+    public static Survey create(Long userId, SurveySatisfaction satisfaction) {
+        return new Survey(userId, satisfaction);
+    }
+}

--- a/src/main/java/com/picktory/domain/survey/enums/SurveySatisfaction.java
+++ b/src/main/java/com/picktory/domain/survey/enums/SurveySatisfaction.java
@@ -1,0 +1,5 @@
+package com.picktory.domain.survey.enums;
+
+public enum SurveySatisfaction {
+    GOOD, SOSO, BAD
+}

--- a/src/main/java/com/picktory/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/picktory/domain/survey/repository/SurveyRepository.java
@@ -1,0 +1,10 @@
+package com.picktory.domain.survey.repository;
+
+import com.picktory.domain.survey.entity.Survey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+}

--- a/src/main/java/com/picktory/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/picktory/domain/survey/service/SurveyService.java
@@ -1,0 +1,25 @@
+package com.picktory.domain.survey.service;
+
+import com.picktory.domain.survey.dto.SurveyRequest;
+import com.picktory.domain.survey.dto.SurveyResponse;
+import com.picktory.domain.survey.entity.Survey;
+import com.picktory.domain.survey.repository.SurveyRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+    private final SurveyRepository surveyRepository;
+
+    /**
+     * 설문조사 응답 생성
+     */
+    @Transactional
+    public SurveyResponse submitSurvey(Long userId, SurveyRequest request) {
+        Survey survey = surveyRepository.save(Survey.create(userId, request.getSurveySatisfaction()));
+        return new SurveyResponse(survey.getId(), survey.getSurveySatisfaction());
+    }
+}

--- a/src/main/java/com/picktory/domain/user/controller/UserController.java
+++ b/src/main/java/com/picktory/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.picktory.domain.user.controller;
 
 import com.picktory.common.BaseResponse;
+import com.picktory.config.auth.AuthenticationService;
 import com.picktory.domain.user.dto.UserResponse;
+import com.picktory.domain.user.entity.User;
 import com.picktory.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final AuthenticationService authenticationService;
 
     /**
      * 내 정보 조회 API
@@ -53,5 +56,14 @@ public class UserController {
         log.info("Logout request received");
         userService.logout();
         return ResponseEntity.ok(BaseResponse.success(null, "로그아웃 성공"));
+    }
+
+    /**
+     * 설문조사 대상자 검사 API
+     */
+    @GetMapping("/users/me/survey-target")
+    public ResponseEntity<Boolean> isSurveyTarget() {
+        User currentUser = authenticationService.getAuthenticatedUser();
+        return ResponseEntity.ok(userService.isSurveyTarget(currentUser));
     }
 }

--- a/src/main/java/com/picktory/domain/user/entity/User.java
+++ b/src/main/java/com/picktory/domain/user/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    @Column(nullable = false)
+    private boolean isSurveyExcluded = false;
+
     @Builder
     public User(Long id, Long kakaoId, String nickname) {
         this.id = id;
@@ -49,5 +52,9 @@ public class User extends BaseEntity {
     public void reactivate() {
         this.isDeleted = false;
         this.deletedAt = null;
+    }
+
+    public void markSurveyExcluded() {
+        this.isSurveyExcluded = true;
     }
 }

--- a/src/main/java/com/picktory/domain/user/service/UserService.java
+++ b/src/main/java/com/picktory/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import com.picktory.common.exception.BaseException;
 import com.picktory.common.BaseResponseStatus;
 import com.picktory.domain.auth.refresh.service.RefreshTokenService;
 import com.picktory.domain.bundle.repository.BundleRepository;
-import com.picktory.domain.survey.repository.SurveyRepository;
 import com.picktory.domain.user.dto.UserResponse;
 import com.picktory.domain.user.entity.User;
 import com.picktory.domain.user.repository.UserRepository;
@@ -28,9 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final KakaoClient kakaoClient;
     private final RefreshTokenService refreshTokenService;
-
     private final BundleRepository bundleRepository;
-    private final SurveyRepository surveyRepository;
 
     /**
      * 현재 인증된 사용자의 정보를 조회합니다.


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> GET /api/v1/users/me/survey-target (설문조사 대상자 확인 API)
- 헬스체크st로 호출해서 설문조사 대상자를 판별할 수 있도록 함
- 보따리 수가 1개인 최초 생성 유저만 설문 대상이 되며, 해당 로직은 도메인 모델 내부에서 한 번만 평가되며 플래그로 관리됨
- https://www.notion.so/API-46211c95cd2f424c901a930c8dfe9b6e?p=1efa47b7b9918088bc8ec90082cadd19&pm=s

<br>

> POST /api/v1/surveys (설문 응답 제출 API)
- 설문조사 대상자 확인 API 결과가 true일 경우 실행 가능한 설문이 제출될 수 있도록 함
- https://www.notion.so/API-46211c95cd2f424c901a930c8dfe9b6e?p=1efa47b7b99180d8ac99f0f878823e8c&pm=s


## 🔍 주요 변경사항

- 설문조사 제외 여부(isSurveyExcluded)를 User 도메인 모델이 직접 판단하고 상태를 관리하도록 설계함 
  - GET /api/v1/users/me/survey-target


## 🙏 리뷰어 참고사항

> 노션 명세에 더 자세한 설명과 예시가 있으니 참고하심 편하실 겁니다
> develop에 merge 전에 DB 수정 필요합니다
