### PR TITLE
[fix]: 보따리 정렬 기준 변경 - 미확인 답변완료 보따리, createAt(desc)순서  

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepository.java
@@ -1,0 +1,10 @@
+package com.picktory.domain.bundle.repository;
+
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.user.entity.User;
+
+import java.util.List;
+
+public interface BundleQueryRepository {
+    List<Bundle> findBundlesByUserDesc(User user);
+}

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface BundleQueryRepository {
     List<Bundle> findBundlesByUserDesc(User user);
+    List<Bundle> findTop8BundlesByUserDesc(User user);
+
 }

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepositoryImpl.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepositoryImpl.java
@@ -34,4 +34,23 @@ public class BundleQueryRepositoryImpl implements BundleQueryRepository {
                 .orderBy(sortPriority.asc(), bundle.createdAt.desc())
                 .fetch();
     }
+
+    @Override
+    public List<Bundle> findTop8BundlesByUserDesc(User user) {
+        QBundle bundle = QBundle.bundle;
+
+        NumberExpression<Integer> sortPriority = new CaseBuilder()
+                .when(bundle.status.eq(BundleStatus.COMPLETED)
+                        .and(bundle.isRead.isFalse()))
+                .then(0)
+                .otherwise(1);
+
+        return queryFactory
+                .selectFrom(bundle)
+                .where(bundle.user.eq(user))
+                .orderBy(sortPriority.asc(), bundle.createdAt.desc())
+                .limit(8)
+                .fetch();
+    }
+
 }

--- a/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepositoryImpl.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleQueryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.picktory.domain.bundle.repository;
+
+import com.picktory.domain.bundle.entity.Bundle;
+import com.picktory.domain.bundle.entity.QBundle;
+import com.picktory.domain.bundle.enums.BundleStatus;
+import com.picktory.domain.user.entity.User;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BundleQueryRepositoryImpl implements BundleQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Bundle> findBundlesByUserDesc(User user) {
+        QBundle bundle = QBundle.bundle;
+
+        NumberExpression<Integer> sortPriority = new CaseBuilder()
+                .when(bundle.status.eq(BundleStatus.COMPLETED)
+                        .and(bundle.isRead.isFalse()))
+                .then(0)
+                .otherwise(1);
+
+        return queryFactory
+                .selectFrom(bundle)
+                .where(bundle.user.eq(user))
+                .orderBy(sortPriority.asc(), bundle.createdAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -11,6 +11,7 @@ import com.picktory.domain.bundle.dto.BundleResponse;
 
 import com.picktory.domain.bundle.entity.Bundle;
 import com.picktory.domain.bundle.enums.BundleStatus;
+import com.picktory.domain.bundle.repository.BundleQueryRepository;
 import com.picktory.domain.bundle.repository.BundleRepository;
 import com.picktory.domain.gift.dto.*;
 import com.picktory.domain.gift.entity.Gift;
@@ -39,6 +40,7 @@ public class BundleService {
     private final BundleRepository bundleRepository;
     private final AuthenticationService authenticationService;
     private final GiftService giftService;
+    private final BundleQueryRepository bundleQueryRepository;
 
     /**
      * 보따리 생성
@@ -105,9 +107,10 @@ public class BundleService {
      */
     @Transactional(readOnly = true)
     public List<BundleListResponse> getMyBundles(User user) {
-        List<Bundle> bundles = bundleRepository.findByUserIdOrderByUpdatedAtDesc(user.getId());
+        List<Bundle> bundles = bundleQueryRepository.findBundlesByUserDesc(user);
         return BundleListResponse.listFrom(bundles);
     }
+
 
     /**
      * 사용자의 최신 8개 보따리 목록 조회

--- a/src/main/java/com/picktory/domain/bundle/service/BundleService.java
+++ b/src/main/java/com/picktory/domain/bundle/service/BundleService.java
@@ -118,7 +118,7 @@ public class BundleService {
     @Transactional(readOnly = true)
     public List<BundleMainListResponse> getUserMainBundles() {
         User currentUser = authenticationService.getAuthenticatedUser();
-        List<Bundle> bundles = bundleRepository.findTop8ByUser_IdOrderByUpdatedAtDesc(currentUser.getId());
+        List<Bundle> bundles = bundleQueryRepository.findTop8BundlesByUserDesc(currentUser);
         return BundleMainListResponse.listFrom(bundles);
     }
 


### PR DESCRIPTION
# Pull Request

## 💡 PR 요약

> 보따리 정렬 기준 변경 - 미확인 답변완료 보따리, createAt(desc)순서로 변경했고, 
api/v1/bundles
api/v1/bundles/main
두 api에 다 적용 했습니다.

## 🙏 리뷰어 참고사항

> 수정 요구사항이 이게 맞는지, 맞다면 지금은이정도만 고쳐도 될지 (기존 응답 dto에 updateAt가 사용되고 있었고, 현재는 정렬 로직만 변경하고 부수적인 부분들은 건들지 않은 상태입니다 - > 건들고 싶으시면 보완하셔도 되구 PR 내리고 재작업하셔두 됩니다!)

## 📋 추가 컨텍스트 (선택)

> PR에 대한 추가적인 설명이나 컨텍스트가 있다면 작성해주세요
