### PR TITLE
Feature/delete bundles on withdrawal

### DIFF
--- a/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
+++ b/src/main/java/com/picktory/domain/bundle/repository/BundleRepository.java
@@ -27,6 +27,8 @@ public interface BundleRepository extends JpaRepository<Bundle, Long> {
      */
     List<Bundle> findTop8ByUser_IdOrderByUpdatedAtDesc(Long userId);
 
+    void deleteAllByUserId(Long userId);
+
 
     Optional<Bundle> findByIdAndStatus(Long id, BundleStatus status);
 }

--- a/src/main/java/com/picktory/domain/user/service/UserService.java
+++ b/src/main/java/com/picktory/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.picktory.domain.user.service;
 import com.picktory.common.exception.BaseException;
 import com.picktory.common.BaseResponseStatus;
 import com.picktory.domain.auth.refresh.service.RefreshTokenService;
+import com.picktory.domain.bundle.repository.BundleRepository;
 import com.picktory.domain.user.dto.UserResponse;
 import com.picktory.domain.user.entity.User;
 import com.picktory.domain.user.repository.UserRepository;
@@ -26,6 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final KakaoClient kakaoClient;
     private final RefreshTokenService refreshTokenService;
+    private final BundleRepository bundleRepository;
 
     /**
      * 현재 인증된 사용자의 정보를 조회합니다.
@@ -51,13 +53,16 @@ public class UserService {
         log.info("Processing withdrawal for user: {}", user.getId());
 
         try {
-            // 1. 카카오 계정 연결 해제
+            // 1. 사용자의 모든 보따리 삭제
+            bundleRepository.deleteAllByUserId(user.getId());
+
+            // 2. 카카오 계정 연결 해제
             kakaoClient.unlinkKakaoAccount(user.getKakaoId());
 
-            // 2. 리프레시 토큰 삭제
+            // 3. 리프레시 토큰 삭제
             refreshTokenService.deleteByUserId(user.getId());
 
-            // 3. 사용자 삭제 처리
+            // 4. 사용자 삭제 처리
             user.delete();
 
             log.info("User successfully withdrawn: {}", user.getId());


### PR DESCRIPTION
# Pull Request
## 💡 PR 요약
회원 탈퇴 시 사용자의 모든 보따리 데이터를 삭제하는 기능을 추가했습니다. 이전에는 회원 탈퇴 시 보따리 데이터가 유지되어 재가입 시 기존 보따리가 그대로 표시되는 문제가 있었습니다. 이 수정으로 UI에서 안내하는 내용과 실제 동작이 일치하게 되었습니다.

## 🔍 주요 변경사항
- `BundleRepository`에 `deleteAllByUserId` 메서드 추가
- `UserService`의 `withdraw()` 메서드에 보따리 삭제 로직 추가
- 사용자 정보 삭제 처리 전 보따리 데이터를 먼저 삭제하도록 순서 조정

## 🔗 연관된 이슈
해당 사항 없음

## 📸 스크린샷 (선택)
해당 사항 없음 (백엔드 로직 변경)

## ✅ 체크리스트
- [x] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트 (선택)
이 변경으로 회원 탈퇴 후 재가입 시 설문조사 기능도 의도대로 작동할 것으로 예상됩니다. 이전에는 탈퇴 후 재가입해도 보따리 개수가 유지되어 설문조사 대상자 판별에 문제가 있었지만, 이제 모든 보따리가 삭제되므로 재가입 후 첫 보따리 생성 시 정확히 설문조사 대상자로 식별됩니다.