### PR TITLE
[Fix]: 회원 재가입 시 설문 대상자 플래그 초기화 기능 추가

### DIFF
--- a/src/main/java/com/picktory/domain/user/entity/User.java
+++ b/src/main/java/com/picktory/domain/user/entity/User.java
@@ -52,6 +52,7 @@ public class User extends BaseEntity {
     public void reactivate() {
         this.isDeleted = false;
         this.deletedAt = null;
+        this.isSurveyExcluded = false; // 사용자 재활성화 시 설문 플래그 초기화
     }
 
     public void markSurveyExcluded() {


### PR DESCRIPTION
## 💡 PR 요약
회원이 탈퇴 후 재가입할 때 설문 대상자 플래그(isSurveyExcluded)가 초기화되지 않아, 첫 보따리 생성 후에도 설문 대상자로 표시되지 않는 문제를 수정했습니다.

## 🔍 주요 변경사항
- User 엔티티의 reactivate() 메서드에 isSurveyExcluded 플래그를 초기화하는 코드 추가
- 사용자가 탈퇴 후 재가입할 때 설문 대상자 상태가 초기화되도록 개선
- 재가입 사용자가 첫 보따리 생성 시 올바르게 설문 대상자로 표시되도록 수정

## 🔗 연관된 이슈
해당 이슈가 있다면 여기에 링크해주세요.

## ✅ 체크리스트
- [ ] 테스트 코드를 작성하였나요?
- [x] 관련 문서를 업데이트하였나요?
- [ ] Breaking Change가 있나요?
- [x] 코드 포맷팅과 린트 검사를 완료하였나요?

## 🙏 리뷰어 참고사항


## 📋 추가 컨텍스트
이 변경 사항은 User 클래스의 reactivate() 메서드만 수정하는 것으로, 사용자가 재가입했을 때 설문 플래그를 초기화하는 간단한 수정입니다. UserService나 다른 서비스 로직의 변경은 필요하지 않습니다.